### PR TITLE
moved sockets extension from a requirement to a suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.1.0",
-        "ext-sockets": "*",
         "ext-mbstring": "*"
     },
     "require-dev": {
@@ -43,7 +42,8 @@
         }
     },
     "suggest": {
-        "laudis/neo4j-php-client": "Neo4j-PHP-Client is the most advanced PHP Client for Neo4j"
+        "laudis/neo4j-php-client": "Neo4j-PHP-Client is the most advanced PHP Client for Neo4j",
+        "ext-sockets": "*"
     },
     "scripts": {
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "suggest": {
         "laudis/neo4j-php-client": "Neo4j-PHP-Client is the most advanced PHP Client for Neo4j",
-        "ext-sockets": "*"
+        "ext-sockets": "Needed when using the Bolt\\connection\\Socket"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
Since the stream extension is standard in the PHP installation and does not require the socket's extension, it seems best to move it as a suggests instead of a requirement. This way, people using the Stream socket will not be required to install the socket extension.

Also, thank you for promoting the neo4j-php-client :+1: 

