### PR TITLE
Adding a error message for timeout events

### DIFF
--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -98,6 +98,10 @@ class StreamSocket extends AConnection
     public function read(int $length = 2048): string
     {
         $res = stream_get_contents($this->stream, $length);
+
+        if (stream_get_meta_data($this->stream)["timed_out"])
+            throw new ConnectException('Connection timeout reached after '.$this->timeout.' seconds.');
+
         if (empty($res))
             throw new ConnectException('Read error');
 


### PR DESCRIPTION
This helps the user understand when the issue is a timeout.

I kept getting the 'Read error' error message and it was not helpful. I did a bunch of testing and found out it was a timeout error. This will help anyone else that comes across a timeout to understand what happened.

You can see my journey of troubleshooting here: https://github.com/neo4j-php/neo4j-php-client/issues/83