### PR TITLE
added version method to AProtocol classes

### DIFF
--- a/src/Bolt.php
+++ b/src/Bolt.php
@@ -109,9 +109,10 @@ final class Bolt
 
     /**
      * @link https://7687.org/bolt/bolt-protocol-handshake-specification.html
+     * @return string
      * @throws Exception
      */
-    private function handshake(): float
+    private function handshake(): string
     {
         if (self::$debug)
             echo 'HANDSHAKE';
@@ -128,17 +129,21 @@ final class Bolt
 
     /**
      * Read and compose selected protocol version
+     * @return string
      */
-    private function unpackProtocolVersion(): float
+    private function unpackProtocolVersion(): string
     {
         $result = [];
 
-        foreach (str_split($this->connection->read(4)) as $ch)
+        foreach (str_split($this->connection->read(4)) as $ch) {
             $result[] = unpack('C', $ch)[1] ?? 0;
+        }
 
-        $result = array_reverse($result);
+        while (count($result) > 0 && reset($result) == 0) {
+            array_shift($result);
+        }
 
-        return (float) implode('.', $result);
+        return implode('.', array_reverse($result));
     }
 
     /**

--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -91,5 +91,12 @@ abstract class AProtocol
      *
      * @return string
      */
-    abstract public function getVersion(): string;
+    public function getVersion(): string
+    {
+        if (preg_match("/V([\d_]+)$/", static::class, $match)) {
+            return str_replace('_', '.', $match[1]);
+        }
+
+        throw new Exception('Protocol version class name is not valid');
+    }
 }

--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -16,7 +16,6 @@ use Exception;
  */
 abstract class AProtocol
 {
-
     protected const SUCCESS = 0x70;
     protected const FAILURE = 0x7F;
     protected const IGNORED = 0x7E;
@@ -87,4 +86,10 @@ abstract class AProtocol
         return $output;
     }
 
+    /**
+     * Returns the bolt protocol version as a string.
+     *
+     * @return string
+     */
+    abstract public function getVersion(): string;
 }

--- a/src/protocol/V1.php
+++ b/src/protocol/V1.php
@@ -176,4 +176,8 @@ class V1 extends AProtocol
         return $message;
     }
 
+    public function getVersion(): string
+    {
+        return '1';
+    }
 }

--- a/src/protocol/V1.php
+++ b/src/protocol/V1.php
@@ -175,9 +175,4 @@ class V1 extends AProtocol
 
         return $message;
     }
-
-    public function getVersion(): string
-    {
-        return '1';
-    }
 }

--- a/src/protocol/V2.php
+++ b/src/protocol/V2.php
@@ -12,5 +12,8 @@ namespace Bolt\protocol;
  */
 class V2 extends V1
 {
-
+    public function getVersion(): string
+    {
+        return '2';
+    }
 }

--- a/src/protocol/V2.php
+++ b/src/protocol/V2.php
@@ -12,8 +12,4 @@ namespace Bolt\protocol;
  */
 class V2 extends V1
 {
-    public function getVersion(): string
-    {
-        return '2';
-    }
 }

--- a/src/protocol/V3.php
+++ b/src/protocol/V3.php
@@ -177,4 +177,8 @@ class V3 extends V2
         $this->connection->disconnect();
     }
 
+    public function getVersion(): string
+    {
+        return '3';
+    }
 }

--- a/src/protocol/V3.php
+++ b/src/protocol/V3.php
@@ -176,9 +176,4 @@ class V3 extends V2
         $this->write($this->packer->pack(0x02));
         $this->connection->disconnect();
     }
-
-    public function getVersion(): string
-    {
-        return '3';
-    }
 }

--- a/src/protocol/V4.php
+++ b/src/protocol/V4.php
@@ -101,4 +101,8 @@ class V4 extends V3
         return $message;
     }
 
+    public function getVersion(): string
+    {
+        return '4.0';
+    }
 }

--- a/src/protocol/V4.php
+++ b/src/protocol/V4.php
@@ -100,9 +100,4 @@ class V4 extends V3
 
         return $message;
     }
-
-    public function getVersion(): string
-    {
-        return '4.0';
-    }
 }

--- a/src/protocol/V4_1.php
+++ b/src/protocol/V4_1.php
@@ -12,7 +12,6 @@ namespace Bolt\protocol;
  */
 class V4_1 extends V4
 {
-
     /**
      * @link https://7687.org/bolt/bolt-protocol-message-specification-4.html#request-message---41---hello
      * @link https://7687.org/bolt/bolt-protocol-message-specification-4.html#request-message---43---hello
@@ -24,10 +23,5 @@ class V4_1 extends V4
             $args[0]['routing'] = (object)$args[0]['routing'];
 
         return parent::hello(...$args);
-    }
-
-    public function getVersion(): string
-    {
-        return '4.1';
     }
 }

--- a/src/protocol/V4_1.php
+++ b/src/protocol/V4_1.php
@@ -26,4 +26,8 @@ class V4_1 extends V4
         return parent::hello(...$args);
     }
 
+    public function getVersion(): string
+    {
+        return '4.1';
+    }
 }

--- a/src/protocol/V4_2.php
+++ b/src/protocol/V4_2.php
@@ -12,8 +12,4 @@ namespace Bolt\protocol;
  */
 class V4_2 extends V4_1
 {
-    public function getVersion(): string
-    {
-        return '4.2';
-    }
 }

--- a/src/protocol/V4_2.php
+++ b/src/protocol/V4_2.php
@@ -12,5 +12,8 @@ namespace Bolt\protocol;
  */
 class V4_2 extends V4_1
 {
-
+    public function getVersion(): string
+    {
+        return '4.2';
+    }
 }

--- a/src/protocol/V4_3.php
+++ b/src/protocol/V4_3.php
@@ -46,4 +46,9 @@ class V4_3 extends V4_2
 
         return $message;
     }
+
+    public function getVersion(): string
+    {
+        return '4.3';
+    }
 }

--- a/src/protocol/V4_3.php
+++ b/src/protocol/V4_3.php
@@ -46,9 +46,4 @@ class V4_3 extends V4_2
 
         return $message;
     }
-
-    public function getVersion(): string
-    {
-        return '4.3';
-    }
 }

--- a/src/protocol/V4_4.php
+++ b/src/protocol/V4_4.php
@@ -21,9 +21,4 @@ class V4_4 extends V4_3
             $args[2] = (object)$args[2];
         return parent::route(...$args);
     }
-
-    public function getVersion(): string
-    {
-        return '4.4';
-    }
 }

--- a/src/protocol/V4_4.php
+++ b/src/protocol/V4_4.php
@@ -22,4 +22,8 @@ class V4_4 extends V4_3
         return parent::route(...$args);
     }
 
+    public function getVersion(): string
+    {
+        return '4.4';
+    }
 }


### PR DESCRIPTION
This is a quality of life suggestion.

In the newer versions, the client needs to use instanceof methods to detect versions. It is a lot easier to request the version of any protocol with a simple version method. This simplifies code like this to a one liner:

```php
public static function determineBoltVersion(V3 $bolt): string
{
        if ($bolt instanceof V4_4) {
            return '4.4';
        }
        if ($bolt instanceof V4_3) {
            return '4.3';
        }
        if ($bolt instanceof V4_2) {
            return '4.2';
        }
        if ($bolt instanceof V4_1) {
            return '4.1';
        }
        if ($bolt instanceof V4) {
            return '4.0';
        }

         return '3';
}
```

Gets simplified to:
```php
public static function determineBoltVersion(V3 $bolt): string
{
         return $bolt->getVersion();
}
```

The version notation is the same as these (found on https://7687.org/):

![image](https://user-images.githubusercontent.com/16435930/148078969-0085e0c0-4a93-4e19-9679-e5ce1fe2b923.png)


What do you think @stefanak-michal?