### PR TITLE
Added reconfigurable timeouts on IConnection

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
     </testsuites>
     <php>
         <var name="NEO_USER" value="neo4j"/>
-        <var name="NEO_PASS" value="nothing"/>
+        <var name="NEO_PASS" value="test"/>
     </php>
     <filter>
         <whitelist>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
     </testsuites>
     <php>
         <var name="NEO_USER" value="neo4j"/>
-        <var name="NEO_PASS" value="test"/>
+        <var name="NEO_PASS" value="nothing"/>
     </php>
     <filter>
         <whitelist>

--- a/src/connection/AConnection.php
+++ b/src/connection/AConnection.php
@@ -71,4 +71,9 @@ abstract class AConnection implements IConnection
     {
         return $this->timeout;
     }
+
+    public function setTimeout(float $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
 }

--- a/src/connection/IConnection.php
+++ b/src/connection/IConnection.php
@@ -31,4 +31,6 @@ interface IConnection
     public function getPort(): int;
 
     public function getTimeout(): float;
+
+    public function setTimeout(float $timeout): void;
 }

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -128,9 +128,6 @@ class Socket extends AConnection
         $this->configureTimeout();
     }
 
-    /**
-     * @return void
-     */
     private function configureTimeout(): void
     {
         $timeoutSeconds = floor($this->timeout);

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -142,11 +142,10 @@ class Socket extends AConnection
     }
 
     /**
-     * @return mixed
      * @throws ConnectException
      * @throws ConnectionTimeoutException
      */
-    private function throwConnectException()
+    private function throwConnectException(): void
     {
         $code = socket_last_error($this->socket);
         if ($code === self::RESOURCE_UNAVAILABLE_CODE) {

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -21,7 +21,7 @@ class Socket extends AConnection
      */
     private $socket = false;
 
-    private const RESOURCE_UNAVAILABLE_CODE = 11;
+    private const RESOURCE_UNAVAILABLE_CODE = [11, 10060];
     /** @var float|null */
     private $timetAtTimeoutConfiguration;
 
@@ -148,7 +148,7 @@ class Socket extends AConnection
     private function throwConnectException(): void
     {
         $code = socket_last_error($this->socket);
-        if ($code === self::RESOURCE_UNAVAILABLE_CODE) {
+        if (in_array($code, self::RESOURCE_UNAVAILABLE_CODE)) {
             $timediff = microtime(true) - $this->timetAtTimeoutConfiguration;
             if ($timediff >= $this->timeout) {
                 throw ConnectionTimeoutException::createFromTimeout($this->timeout);

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -42,11 +42,7 @@ class Socket extends AConnection
 
         socket_set_option($this->socket, SOL_TCP, TCP_NODELAY, 1);
         socket_set_option($this->socket, SOL_SOCKET, SO_KEEPALIVE, 1);
-        $timeoutSeconds = floor($this->timeout);
-        $microSeconds = floor(($this->timeout - $timeoutSeconds) * 1000000);
-        $timeoutOption = ['sec' => $timeoutSeconds, 'usec' => $microSeconds];
-        socket_set_option($this->socket, SOL_SOCKET, SO_RCVTIMEO, $timeoutOption);
-        socket_set_option($this->socket, SOL_SOCKET, SO_SNDTIMEO, $timeoutOption);
+        $this->configureTimeout();
 
         $conn = @socket_connect($this->socket, $this->ip, $this->port);
         if (!$conn) {
@@ -124,5 +120,23 @@ class Socket extends AConnection
             @socket_shutdown($this->socket);
             @socket_close($this->socket);
         }
+    }
+
+    public function setTimeout(float $timeout): void
+    {
+        parent::setTimeout($timeout);
+        $this->configureTimeout();
+    }
+
+    /**
+     * @return void
+     */
+    private function configureTimeout(): void
+    {
+        $timeoutSeconds = floor($this->timeout);
+        $microSeconds = floor(($this->timeout - $timeoutSeconds) * 1000000);
+        $timeoutOption = ['sec' => $timeoutSeconds, 'usec' => $microSeconds];
+        socket_set_option($this->socket, SOL_SOCKET, SO_RCVTIMEO, $timeoutOption);
+        socket_set_option($this->socket, SOL_SOCKET, SO_SNDTIMEO, $timeoutOption);
     }
 }

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -5,10 +5,6 @@ namespace Bolt\connection;
 use Bolt\Bolt;
 use Bolt\error\ConnectException;
 use Bolt\error\ConnectionTimeoutException;
-use function microtime;
-use function round;
-use function socket_get_status;
-use function socket_strerror;
 
 /**
  * Socket class

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -21,7 +21,7 @@ class Socket extends AConnection
      */
     private $socket = false;
 
-    private const RESOURCE_UNAVAILABLE_CODE = [11, 10060];
+    private const POSSIBLE_TIMEOUTS_CODES = [11, 10060];
     /** @var float|null */
     private $timetAtTimeoutConfiguration;
 
@@ -76,7 +76,7 @@ class Socket extends AConnection
             $this->printHex($buffer);
 
         while (0 < $size) {
-            $sent = socket_write($this->socket, $buffer, $size);
+            $sent = @socket_write($this->socket, $buffer, $size);
             if ($sent === false) {
                 $this->throwConnectException();
             }
@@ -101,7 +101,7 @@ class Socket extends AConnection
         }
 
         do {
-            $readed = socket_read($this->socket, $length - mb_strlen($output, '8bit'), PHP_BINARY_READ);
+            $readed = @socket_read($this->socket, $length - mb_strlen($output, '8bit'), PHP_BINARY_READ);
             if ($readed === false) {
                 $this->throwConnectException();
             }
@@ -148,7 +148,7 @@ class Socket extends AConnection
     private function throwConnectException(): void
     {
         $code = socket_last_error($this->socket);
-        if (in_array($code, self::RESOURCE_UNAVAILABLE_CODE)) {
+        if (in_array($code, self::POSSIBLE_TIMEOUTS_CODES)) {
             $timediff = microtime(true) - $this->timetAtTimeoutConfiguration;
             if ($timediff >= $this->timeout) {
                 throw ConnectionTimeoutException::createFromTimeout($this->timeout);

--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -6,8 +6,6 @@ namespace Bolt\connection;
 use Bolt\Bolt;
 use Bolt\error\ConnectException;
 use Bolt\error\ConnectionTimeoutException;
-use function floor;
-use function stream_set_timeout;
 
 /**
  * Stream socket class

--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -5,6 +5,7 @@ namespace Bolt\connection;
 
 use Bolt\Bolt;
 use Bolt\error\ConnectException;
+use Bolt\error\ConnectionTimeoutException;
 use function floor;
 use function stream_set_timeout;
 
@@ -99,7 +100,7 @@ class StreamSocket extends AConnection
         $res = stream_get_contents($this->stream, $length);
 
         if (stream_get_meta_data($this->stream)["timed_out"])
-            throw new ConnectException('Connection timeout reached after '.$this->timeout.' seconds.');
+            throw ConnectionTimeoutException::createFromTimeout($this->timeout);
 
         if (empty($res))
             throw new ConnectException('Read error');

--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -5,6 +5,8 @@ namespace Bolt\connection;
 
 use Bolt\Bolt;
 use Bolt\error\ConnectException;
+use function floor;
+use function stream_set_timeout;
 
 /**
  * Stream socket class
@@ -66,10 +68,7 @@ class StreamSocket extends AConnection
             }
         }
 
-        $timeout = (int) floor($this->timeout);
-        if (!stream_set_timeout($this->stream, $timeout, (int) floor(($this->timeout - $timeout) * 1000000))) {
-            throw new ConnectException('Cannot set timeout on stream');
-        }
+        $this->setTimeoutOnStream();
 
         return true;
     }
@@ -120,4 +119,21 @@ class StreamSocket extends AConnection
             stream_socket_shutdown($this->stream, STREAM_SHUT_RDWR);
     }
 
+    public function setTimeout(float $timeout): void
+    {
+        parent::setTimeout($timeout);
+        $this->setTimeoutOnStream();
+    }
+
+    /**
+     * @return void
+     * @throws ConnectException
+     */
+    private function setTimeoutOnStream(): void
+    {
+        $timeout = (int)floor($this->timeout);
+        if (!stream_set_timeout($this->stream, $timeout, (int)floor(($this->timeout - $timeout) * 1000000))) {
+            throw new ConnectException('Cannot set timeout on stream');
+        }
+    }
 }

--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -67,7 +67,7 @@ class StreamSocket extends AConnection
             }
         }
 
-        $this->setTimeoutOnStream();
+        $this->configureTimeout();
 
         return true;
     }
@@ -121,14 +121,14 @@ class StreamSocket extends AConnection
     public function setTimeout(float $timeout): void
     {
         parent::setTimeout($timeout);
-        $this->setTimeoutOnStream();
+        $this->configureTimeout();
     }
 
     /**
      * @return void
      * @throws ConnectException
      */
-    private function setTimeoutOnStream(): void
+    private function configureTimeout(): void
     {
         $timeout = (int)floor($this->timeout);
         if (!stream_set_timeout($this->stream, $timeout, (int)floor(($this->timeout - $timeout) * 1000000))) {

--- a/src/error/ConnectionTimeoutException.php
+++ b/src/error/ConnectionTimeoutException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bolt\error;
+
+class ConnectionTimeoutException extends ConnectException
+{
+    public static function createFromTimeout(float $timeout): self
+    {
+        return new self('Connection timeout reached after '.$timeout.' seconds.');
+    }
+}

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -41,7 +41,7 @@ final class AConnectionTest extends TestCase
         } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
-            $this->assertEqualsWithDelta(1.5, $newTime - $time, 0.2);
+            $this->assertGreaterThanOrEqual(1.5, $newTime - $time);
         }
     }
 
@@ -63,7 +63,7 @@ final class AConnectionTest extends TestCase
         } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
-            $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
+            $this->assertGreaterThanOrEqual(1.0, $newTime - $time);
         }
     }
 
@@ -86,7 +86,7 @@ final class AConnectionTest extends TestCase
         } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
-            $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
+            $this->assertGreaterThanOrEqual(1.0, $newTime - $time);
         }
 
         $socket->setTimeout(100.0);
@@ -109,7 +109,7 @@ final class AConnectionTest extends TestCase
         } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
-            $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
+            $this->assertGreaterThanOrEqual(1.0, $newTime - $time);
         }
     }
 

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -73,9 +73,8 @@ final class AConnectionTest extends TestCase
     public function testTimeoutRecoverAndReset(string $alias): void
     {
         $socket = $this->getConnection($alias);
-        /** @var V4 $protocol */
         $protocol = (new Bolt($socket))->build();
-        $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+        $protocol->init(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
 
         $time = microtime(true);
         try {
@@ -95,7 +94,7 @@ final class AConnectionTest extends TestCase
         } catch (MessageException $e) {
             echo $e->getMessage();
             $protocol = (new Bolt($socket))->build();
-            $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+            $protocol->init(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
         }
 
         $socket->setTimeout(1.0);

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -73,9 +73,8 @@ final class AConnectionTest extends TestCase
     public function testTimeoutRecoverAndReset(string $alias): void
     {
         $socket = $this->getConnection($alias);
-        $streamSocket = new StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', (int) ($GLOBALS['NEO_PORT'] ?? 7687), 1);
         /** @var V4 $protocol */
-        $protocol = (new Bolt($streamSocket))->build();
+        $protocol = (new Bolt($socket))->build();
         $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
 
         $time = microtime(true);
@@ -90,16 +89,16 @@ final class AConnectionTest extends TestCase
             $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
         }
 
-        $streamSocket->setTimeout(100.0);
+        $socket->setTimeout(100.0);
         try {
             $protocol->reset();
         } catch (MessageException $e) {
             echo $e->getMessage();
-            $protocol = (new Bolt($streamSocket))->build();
+            $protocol = (new Bolt($socket))->build();
             $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
         }
 
-        $streamSocket->setTimeout(1.0);
+        $socket->setTimeout(1.0);
 
         $time = microtime(true);
         try {

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -17,8 +17,8 @@ final class AConnectionTest extends TestCase
     public function provideConnections(): array
     {
         return [
-            [StreamSocket::class],
-            [Socket::class],
+            StreamSocket::class => [StreamSocket::class],
+            Socket::class => [Socket::class],
         ];
     }
 

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -11,7 +11,6 @@ use Bolt\error\MessageException;
 use Bolt\helpers\Auth;
 use Bolt\protocol\V4;
 use PHPUnit\Framework\TestCase;
-use function microtime;
 
 final class AConnectionTest extends TestCase
 {

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -37,13 +37,12 @@ final class AConnectionTest extends TestCase
             $protocol->run('FOREACH ( i IN range(1,10000) | 
   MERGE (d:Day {day: i})
 )');
+            $this->fail('No timeout error triggered');
         } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
             $this->assertEqualsWithDelta(1.5, $newTime - $time, 0.2);
         }
-
-        self::assertTrue(true);
     }
 
     /**
@@ -99,7 +98,6 @@ final class AConnectionTest extends TestCase
             $protocol = (new Bolt($streamSocket))->build();
             $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
         }
-        $this->assertTrue(true);
 
         $streamSocket->setTimeout(1.0);
 

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -6,7 +6,7 @@ use Bolt\Bolt;
 use Bolt\connection\IConnection;
 use Bolt\connection\Socket;
 use Bolt\connection\StreamSocket;
-use Bolt\error\ConnectException;
+use Bolt\error\ConnectionTimeoutException;
 use Bolt\error\MessageException;
 use Bolt\helpers\Auth;
 use Bolt\protocol\V4;
@@ -38,7 +38,7 @@ final class AConnectionTest extends TestCase
             $protocol->run('FOREACH ( i IN range(1,10000) | 
   MERGE (d:Day {day: i})
 )');
-        } catch (ConnectException $e) {
+        } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
             $this->assertEqualsWithDelta(1.5, $newTime - $time, 0.2);
@@ -62,7 +62,7 @@ final class AConnectionTest extends TestCase
   MERGE (d:Day {day: i})
 )');
             $this->fail('No timeout error triggered');
-        } catch (ConnectException $e) {
+        } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
             $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
@@ -86,7 +86,7 @@ final class AConnectionTest extends TestCase
                 MERGE (d:Day {day: i})
             )');
             $this->fail('No timeout error triggered');
-        } catch (ConnectException $e) {
+        } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
             $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
@@ -110,7 +110,7 @@ final class AConnectionTest extends TestCase
                 MERGE (d:Day {day: i})
             )');
             $this->fail('No timeout error triggered');
-        } catch (ConnectException $e) {
+        } catch (ConnectionTimeoutException $e) {
             $newTime = microtime(true);
 
             $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);

--- a/tests/connection/StreamSocketTest.php
+++ b/tests/connection/StreamSocketTest.php
@@ -5,8 +5,12 @@ namespace Bolt\tests\connection;
 use Bolt\Bolt;
 use Bolt\connection\StreamSocket;
 use Bolt\error\ConnectException;
+use Bolt\error\MessageException;
+use Bolt\helpers\Auth;
+use Bolt\protocol\V4;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use function microtime;
 
 final class StreamSocketTest extends TestCase
 {
@@ -18,7 +22,7 @@ final class StreamSocketTest extends TestCase
         $socket = new StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', (int) ($GLOBALS['NEO_PORT'] ?? 7687), 1.5);
         $bolt = new Bolt($socket);
         $protocol = $bolt->build();
-        $protocol->init(\Bolt\helpers\Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+        $protocol->init(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
 
         $time = microtime(true);
         try {
@@ -42,13 +46,57 @@ final class StreamSocketTest extends TestCase
         $socket = new StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', (int) ($GLOBALS['NEO_PORT'] ?? 7687), 1);
         $bolt = new Bolt($socket);
         $protocol = $bolt->build();
-        $protocol->init(\Bolt\helpers\Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+        $protocol->init(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
 
         $time = microtime(true);
         try {
             $protocol->run('FOREACH ( i IN range(1,10000) | 
   MERGE (d:Day {day: i})
 )');
+            $this->fail('No timeout error triggered');
+        } catch (ConnectException $e) {
+            $newTime = microtime(true);
+
+            $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
+        }
+    }
+
+    public function testTimeoutRecoverAndReset(): void
+    {
+        $streamSocket = new StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', (int) ($GLOBALS['NEO_PORT'] ?? 7687), 1);
+        /** @var V4 $protocol */
+        $protocol = (new Bolt($streamSocket))->build();
+        $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+
+        $time = microtime(true);
+        try {
+            $protocol->run('FOREACH ( i IN range(1,10000) | 
+                MERGE (d:Day {day: i})
+            )');
+            $this->fail('No timeout error triggered');
+        } catch (ConnectException $e) {
+            $newTime = microtime(true);
+
+            $this->assertEqualsWithDelta(1.0, $newTime - $time, 0.2);
+        }
+
+        $streamSocket->setTimeout(100.0);
+        try {
+            $protocol->reset();
+        } catch (MessageException $e) {
+            echo $e->getMessage();
+            $protocol = (new Bolt($streamSocket))->build();
+            $protocol->hello(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+        }
+        $this->assertTrue(true);
+
+        $streamSocket->setTimeout(1.0);
+
+        $time = microtime(true);
+        try {
+            $protocol->run('FOREACH ( i IN range(1,10000) | 
+                MERGE (d:Day {day: i})
+            )');
             $this->fail('No timeout error triggered');
         } catch (ConnectException $e) {
             $newTime = microtime(true);


### PR DESCRIPTION
Hello,

This PR is as a response to this issue: https://github.com/neo4j-php/neo4j-php-client/issues/102

Reconfigurable timeouts make it possible to set up timeout on a per-query basis, which is essential to get in line with the official drivers.

I also included a test case showing how to recover from timeouts.

I hope everything is up to standard,


Kind regards,

Ghlen