### PR TITLE
Long query fixes

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -20,6 +20,7 @@ jobs:
         image: neo4j:${{ matrix.neo4j-version }}
         env:
           NEO4J_AUTH: neo4j/nothing
+          NEO4JLABS_PLUGINS: '["apoc"]'
         ports:
           - 7687:7687
           - 7474:7474

--- a/src/connection/Socket.php
+++ b/src/connection/Socket.php
@@ -153,7 +153,8 @@ class Socket extends AConnection
             if ($timediff >= $this->timeout) {
                 throw ConnectionTimeoutException::createFromTimeout($this->timeout);
             }
+        } else if ($code !== 0) {
+            throw new ConnectException(socket_strerror($code), $code);
         }
-        throw new ConnectException(socket_strerror($code), $code);
     }
 }

--- a/src/connection/StreamSocket.php
+++ b/src/connection/StreamSocket.php
@@ -100,9 +100,6 @@ class StreamSocket extends AConnection
         if (stream_get_meta_data($this->stream)["timed_out"])
             throw ConnectionTimeoutException::createFromTimeout($this->timeout);
 
-        if (empty($res))
-            throw new ConnectException('Read error');
-
         if (Bolt::$debug)
             $this->printHex($res, false);
 

--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -71,7 +71,7 @@ abstract class AProtocol
         $msg = '';
         while (true) {
             $header = $this->connection->read(2);
-            if (ord($header[0]) == 0x00 && ord($header[1]) == 0x00)
+            if ($msg !== '' && ord($header[0]) == 0x00 && ord($header[1]) == 0x00)
                 break;
             $length = unpack('n', $header)[1] ?? 0;
             $msg .= $this->connection->read($length);

--- a/tests/connection/AConnectionTest.php
+++ b/tests/connection/AConnectionTest.php
@@ -45,6 +45,22 @@ final class AConnectionTest extends TestCase
         }
     }
 
+
+    /**
+     * @dataProvider provideConnections
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testLongNoTimeout(string $alias): void
+    {
+        $socket = $this->getConnection($alias);
+        $protocol = (new Bolt($socket))->build();
+        $socket->setTimeout(200);
+        $protocol->init(Auth::basic($GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']));
+
+        $protocol->run('CALL apoc.util.sleep(150000)', [], ['tx_timeout' => 150000]);
+    }
+
     /**
      * @dataProvider provideConnections
      */


### PR DESCRIPTION
When running queries over 120 seconds, the sockets will read an empty string, leading to cryptic errors: 
https://github.com/neo4j-php/neo4j-php-client/issues/102

To solve this, I had to remove the assumption that empty strings result in a read error, and continue reading if a chunking symbol `0x00 0x00` appeared when no message has been read yet.

According to the tests, everything still works