### PR TITLE
Enabled server states

### DIFF
--- a/src/protocol/ServerState/AServerState.php
+++ b/src/protocol/ServerState/AServerState.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+use Bolt\protocol\Signatures;
+
+abstract class AServerState implements IServerState
+{
+    public function transitionAfterHandshake(bool $success): int
+    {
+        return ServerStates::UNKNOWN;
+    }
+
+    protected function basicTransition(?int $response, int $onSuccessState, int $onFailureState): ?int
+    {
+        if ($response === Signatures::SUCCESS) {
+            return $onSuccessState;
+        }
+
+        if ($response === Signatures::FAILURE) {
+            return $onFailureState;
+        }
+
+        return null;
+    }
+}

--- a/src/protocol/ServerState/AcceptsBothSignals.php
+++ b/src/protocol/ServerState/AcceptsBothSignals.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+trait AcceptsBothSignals
+{
+    public function transitionFromSignal(int $signal): int
+    {
+        if ($signal === ServerStateSignal::INTERRUPT) {
+            return ServerStates::INTERRUPTED;
+        }
+
+        return ServerStates::DEFUNCT;
+    }
+}

--- a/src/protocol/ServerState/IServerState.php
+++ b/src/protocol/ServerState/IServerState.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+interface IServerState
+{
+    /**
+     * Create the server state transition given the provided request and response signature.
+     *
+     * @param int $message  The request signature.
+     * @param int|null $response The response signature.
+     *
+     * @return int  The next expected server state.
+     */
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int;
+
+    /**
+     * Create the server state transition when a given signal occurs.
+     *
+     * @param int $signal The signal that occurs.
+     *
+     * @return int  The next expected server state.
+     */
+    public function transitionFromSignal(int $signal): int;
+
+    public function transitionAfterHandshake(bool $success): int;
+
+    public function getName(): string;
+}

--- a/src/protocol/ServerState/ServerStateFactory.php
+++ b/src/protocol/ServerState/ServerStateFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+
+use Bolt\protocol\AProtocol;
+use Bolt\protocol\V3;
+use Bolt\protocol\V4;
+use Bolt\protocol\V4_3;
+use function is_a;
+
+class ServerStateFactory
+{
+    private int $version;
+    private const IMPLEMENTATION_MAPPING = [
+        0x040300 => [
+            \Bolt\protocol\ServerState\V1\Defunct::class,
+            \Bolt\protocol\ServerState\V1\Disconnected::class,
+            \Bolt\protocol\ServerState\V3\Failed::class,
+            \Bolt\protocol\ServerState\V4_3\Ready::class,
+            \Bolt\protocol\ServerState\V4_0\Streaming::class,
+            \Bolt\protocol\ServerState\V3\TxReady::class,
+            \Bolt\protocol\ServerState\V4_0\TxStreaming::class,
+        ],
+        0x040000 => [
+            \Bolt\protocol\ServerState\V1\Defunct::class,
+            \Bolt\protocol\ServerState\V1\Disconnected::class,
+            \Bolt\protocol\ServerState\V3\Failed::class,
+            \Bolt\protocol\ServerState\V3\Ready::class,
+            \Bolt\protocol\ServerState\V4_0\Streaming::class,
+            \Bolt\protocol\ServerState\V3\TxReady::class,
+            \Bolt\protocol\ServerState\V4_0\TxStreaming::class,
+        ],
+        0x030000 => [
+            \Bolt\protocol\ServerState\V1\Defunct::class,
+            \Bolt\protocol\ServerState\V1\Disconnected::class,
+            \Bolt\protocol\ServerState\V3\Failed::class,
+            \Bolt\protocol\ServerState\V3\Ready::class,
+            \Bolt\protocol\ServerState\V3\TxReady::class,
+            \Bolt\protocol\ServerState\V3\TxStreaming::class,
+        ],
+        0x010000 => [
+            \Bolt\protocol\ServerState\V1\Connected::class,
+            \Bolt\protocol\ServerState\V1\Defunct::class,
+            \Bolt\protocol\ServerState\V1\Disconnected::class,
+            \Bolt\protocol\ServerState\V1\Failed::class,
+            \Bolt\protocol\ServerState\V1\Interrupted::class,
+            \Bolt\protocol\ServerState\V1\Ready::class,
+            \Bolt\protocol\ServerState\V1\Streaming::class
+        ],
+    ];
+
+    public function __construct(int $version)
+    {
+        $this->version = $version;
+    }
+
+    public function buildNewState(int $state): IServerState
+    {
+        return (self::IMPLEMENTATION_MAPPING[$this->version][$state] ?? Unknown::class)();
+    }
+
+    public static function createFromProtocol(AProtocol $protocol): self
+    {
+        if (is_a($protocol, V4_3::class)) {
+            return new self(0x040300);
+        }
+        if (is_a($protocol, V4::class)) {
+            return new self(0x040300);
+        }
+        if (is_a($protocol, V3::class)) {
+            return new self(0x030000);
+        }
+
+        return new self(0x010000);
+    }
+}

--- a/src/protocol/ServerState/ServerStateFactory.php
+++ b/src/protocol/ServerState/ServerStateFactory.php
@@ -57,7 +57,7 @@ class ServerStateFactory
 
     public function buildNewState(int $state): IServerState
     {
-        return (self::IMPLEMENTATION_MAPPING[$this->version][$state] ?? Unknown::class)();
+        return new (self::IMPLEMENTATION_MAPPING[$this->version][$state] ?? Unknown::class)();
     }
 
     public static function createFromProtocol(AProtocol $protocol): self

--- a/src/protocol/ServerState/ServerStateFactory.php
+++ b/src/protocol/ServerState/ServerStateFactory.php
@@ -57,7 +57,9 @@ class ServerStateFactory
 
     public function buildNewState(int $state): IServerState
     {
-        return new (self::IMPLEMENTATION_MAPPING[$this->version][$state] ?? Unknown::class)();
+        $class = self::IMPLEMENTATION_MAPPING[$this->version][$state] ?? Unknown::class;
+
+        return new $class();
     }
 
     public static function createFromProtocol(AProtocol $protocol): self

--- a/src/protocol/ServerState/ServerStateSignal.php
+++ b/src/protocol/ServerState/ServerStateSignal.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+class ServerStateSignal
+{
+    public const INTERRUPT = 0;
+    public const DISCONNECT = 1;
+}

--- a/src/protocol/ServerState/ServerStates.php
+++ b/src/protocol/ServerState/ServerStates.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+use Bolt\protocol\MainBoltVersions;
+
+class ServerStates
+{
+    public const CONNECTED = 0;
+    public const DEFUNCT = 1;
+    public const DISCONNECTED = 2;
+    public const FAILED = 3;
+    public const INTERRUPTED = 4;
+    public const READY = 5;
+    public const STREAMING = 6;
+    public const TX_READY = 7;
+    public const TX_STREAMING = 8;
+
+    public const UNKNOWN = -1;
+}

--- a/src/protocol/ServerState/Unknown.php
+++ b/src/protocol/ServerState/Unknown.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bolt\protocol\ServerState;
+
+class Unknown extends AServerState
+{
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        return ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'UNKNOWN';
+    }
+}

--- a/src/protocol/ServerState/V1/Connected.php
+++ b/src/protocol/ServerState/V1/Connected.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\Signatures;
+
+/**
+ * State representing when a protocol connection has been established and a handshake has been completed successfully, but not yet authenticated.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---connected
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---connected
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---connected
+ */
+class Connected extends AServerState
+{
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            $message === Signatures::INIT &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::DEFUNCT)
+        ) {
+            return $transition;
+        }
+
+        return ServerStates::UNKNOWN;
+    }
+
+    public function transitionFromSignal(int $signal): int
+    {
+        if ($signal === ServerStateSignal::DISCONNECT) {
+            return ServerStates::DEFUNCT;
+        }
+
+        return ServerStates::CONNECTED;
+    }
+
+    public function getName(): string
+    {
+        return 'CONNECTED';
+    }
+}

--- a/src/protocol/ServerState/V1/Defunct.php
+++ b/src/protocol/ServerState/V1/Defunct.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+
+/**
+ * This is not strictly a connection state, but is instead a logical state that exists after a connection has been closed. When DEFUNCT, a connection is permanently not usable.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---defunct
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---defunct
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---defunct
+ */
+class Defunct extends AServerState
+{
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        return ServerStates::DEFUNCT;
+    }
+
+    public function transitionFromSignal(int $signal): int
+    {
+        return ServerStates::DEFUNCT;
+    }
+
+    public function getName(): string
+    {
+        return 'DEFUNCT';
+    }
+}

--- a/src/protocol/ServerState/V1/Disconnected.php
+++ b/src/protocol/ServerState/V1/Disconnected.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+
+/**
+ * A logical state when there isn't an established socket connection.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---disconnected
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---disconnected
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---disconnected
+ */
+class Disconnected extends AServerState
+{
+    public function transitionAfterHandshake(bool $success): int
+    {
+        if ($success) {
+            return ServerStates::CONNECTED;
+        }
+
+        return ServerStates::DEFUNCT;
+    }
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        // A disconnected state is a logical state and does nothing when a message is sent to it
+        // Instead, the handshake protocol must manually advance the state to the
+        // CONNECTED state
+        return ServerStates::UNKNOWN;
+    }
+
+    public function transitionFromSignal(int $signal): int
+    {
+        return ServerStates::DISCONNECTED;
+    }
+
+    public function getName(): string
+    {
+        return 'DISCONNECTED';
+    }
+}

--- a/src/protocol/ServerState/V1/Failed.php
+++ b/src/protocol/ServerState/V1/Failed.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+/**
+ * When FAILED, a connection is in a temporarily unusable state. This is generally as the result of encountering a recoverable error. No more work will be processed until the failure has been acknowledged by ACK_FAILURE (V1 Only) or until the connection has been RESET
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---failed
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---failed
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---failed
+ */
+class Failed extends AServerState
+{
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if ($response === Signatures::IGNORED) {
+            if ($message === Signatures::RUN || $message === Signatures::PULL_ALL) {
+                return ServerStates::FAILED;
+            }
+
+            if ($message === Signatures::DISCARD_ALL) {
+                return ServerStates::INTERRUPTED;
+            }
+        }
+
+        if (
+            $message === Signatures::ACK_FAILURE &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::DEFUNCT)
+        ) {
+            return $transition;
+        }
+
+        return ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'FAILED';
+    }
+}

--- a/src/protocol/ServerState/V1/Interrupted.php
+++ b/src/protocol/ServerState/V1/Interrupted.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+/**
+ * This state occurs between the server receiving the jump-ahead <INTERRUPT> and the queued RESET message, (the RESET message triggers an <INTERRUPT>). Most incoming messages are ignored when the server are in an INTERRUPTED state, with the exception of the RESET that allows transition back to READY.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---interrupted
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---interrupted
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---interrupted
+ */
+class Interrupted extends AServerState
+{
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            $message === Signatures::RESET &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::DEFUNCT)
+        ) {
+            return $transition;
+        }
+
+        return ServerStates::INTERRUPTED;
+    }
+
+    public function getName(): string
+    {
+        return 'INTERRUPTED';
+    }
+}

--- a/src/protocol/ServerState/V1/Ready.php
+++ b/src/protocol/ServerState/V1/Ready.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+/**
+ * The READY state can handle the request message RUN and receive a query.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---ready
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---ready
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---ready
+ */
+class Ready extends AServerState
+{
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            ($message === Signatures::RUN) &&
+            $transition = $this->basicTransition($response, ServerStates::STREAMING, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'READY';
+    }
+}

--- a/src/protocol/ServerState/V1/Streaming.php
+++ b/src/protocol/ServerState/V1/Streaming.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+/**
+ * When STREAMING, a result is available for streaming from server to client. This result must be fully consumed or discarded by a client before the server can re-enter the READY state and allow any further queries to be executed.
+ *
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-1.html#server-state---streaming
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---streaming
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---streaming
+ */
+class Streaming extends AServerState
+{
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if ($message === Signatures::PULL_ALL && $response === Signatures::RECORD) {
+            return ServerStates::STREAMING;
+        }
+
+        if (
+            ($message === Signatures::PULL_ALL || $message === Signatures::DISCARD_ALL) &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'STREAMING';
+    }
+}

--- a/src/protocol/ServerState/V3/Failed.php
+++ b/src/protocol/ServerState/V3/Failed.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+class Failed extends AServerState
+{
+    use HandlesGoodbye;
+    use AcceptsBothSignals;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (in_array($message, [Signatures::RUN, Signatures::PULL_ALL, Signatures::DISCARD_ALL], true)) {
+            return ServerStates::FAILED;
+        }
+
+        return $this->handleGoodbyeIfPossible($message, $response) ??
+               ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'CONNECTED';
+    }
+}

--- a/src/protocol/ServerState/V3/HandlesGoodbye.php
+++ b/src/protocol/ServerState/V3/HandlesGoodbye.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\Signatures;
+
+trait HandlesGoodbye
+{
+    public function handleGoodbyeIfPossible(int $message, ?int $response): ?int
+    {
+        if ($message === Signatures::GOODBYE && $response === null) {
+            return ServerStates::DEFUNCT;
+        }
+
+        return null;
+    }
+}

--- a/src/protocol/ServerState/V3/Ready.php
+++ b/src/protocol/ServerState/V3/Ready.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\Signatures;
+
+class Ready extends \Bolt\protocol\ServerState\V1\Ready
+{
+    use HandlesGoodbye;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            $message === Signatures::BEGIN &&
+            $transition = $this->basicTransition($response, ServerStates::TX_READY, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return $this->handleGoodbyeIfPossible($message, $response) ??
+               parent::transitionFromMessage($message, $response);
+    }
+}

--- a/src/protocol/ServerState/V3/TxReady.php
+++ b/src/protocol/ServerState/V3/TxReady.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+/**
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---tx_ready
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---tx_ready
+ */
+class TxReady extends AServerState
+{
+    use AcceptsBothSignals;
+    use HandlesGoodbye;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            ($message === Signatures::COMMIT || $message === Signatures::ROLLBACK) &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        if (
+            $message === Signatures::RUN &&
+            $transition = $this->basicTransition($response, ServerStates::TX_STREAMING, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return $this->handleGoodbyeIfPossible($message, $response) ?? ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'TX_READY';
+    }
+}

--- a/src/protocol/ServerState/V3/TxStreaming.php
+++ b/src/protocol/ServerState/V3/TxStreaming.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\AServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\AcceptsBothSignals;
+use Bolt\protocol\Signatures;
+
+/**
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-3.html#server-state---tx_streaming
+ * @link https://7687.org/bolt/bolt-protocol-server-state-specification-4.html#server-state---tx_streaming
+ */
+class TxStreaming extends AServerState
+{
+    use AcceptsBothSignals;
+    use HandlesGoodbye;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            ($message === Signatures::PULL_ALL || $message === Signatures::DISCARD_ALL) &&
+            $transition = $this->basicTransition($response, ServerStates::TX_READY, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        if (
+            $message === Signatures::RUN &&
+            $transition = $this->basicTransition($response, ServerStates::TX_STREAMING, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return $this->handleGoodbyeIfPossible($message, $response) ??
+               ServerStates::UNKNOWN;
+    }
+
+    public function getName(): string
+    {
+        return 'TX_STREAMING';
+    }
+}

--- a/src/protocol/ServerState/V4_0/Streaming.php
+++ b/src/protocol/ServerState/V4_0/Streaming.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V4_0;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\Signatures;
+
+class Streaming extends \Bolt\protocol\ServerState\V1\Streaming
+{
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            ($message === Signatures::PULL || $message === Signatures::DISCARD) &&
+            $response === Signatures::SUCCESS &&
+            ($data['has_more'] ?? false)
+        ) {
+            return ServerStates::STREAMING;
+        }
+
+        return parent::transitionFromMessage($message, $response);
+    }
+}

--- a/src/protocol/ServerState/V4_0/TxStreaming.php
+++ b/src/protocol/ServerState/V4_0/TxStreaming.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V4_0;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\Signatures;
+
+class TxStreaming extends \Bolt\protocol\ServerState\V3\TxStreaming
+{
+    private int $openResults = 1;
+
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if ($message === Signatures::RUN && $response === Signatures::SUCCESS) {
+            ++$this->openResults;
+        }
+
+        if (
+            ($message === Signatures::PULL || $message === Signatures::DISCARD) &&
+            $response === Signatures::SUCCESS
+        ) {
+            if ($data['has_more'] ?? false) {
+                return ServerStates::TX_STREAMING;
+            }
+
+            --$this->openResults;
+            if ($this->openResults === 0) {
+                return ServerStates::TX_READY;
+            }
+
+            return ServerStates::TX_STREAMING;
+        }
+
+        return parent::transitionFromMessage($message, $response);
+    }
+}

--- a/src/protocol/ServerState/V4_3/Ready.php
+++ b/src/protocol/ServerState/V4_3/Ready.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bolt\protocol\ServerState\V4_3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\Signatures;
+
+class Ready extends \Bolt\protocol\ServerState\V3\Ready
+{
+    public function transitionFromMessage(int $message, ?int $response = null, array $data = []): int
+    {
+        if (
+            $message === Signatures::ROUTE &&
+            $transition = $this->basicTransition($response, ServerStates::READY, ServerStates::FAILED)
+        ) {
+            return $transition;
+        }
+
+        return parent::transitionFromMessage($message, $response);
+    }
+}

--- a/src/protocol/Signatures.php
+++ b/src/protocol/Signatures.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bolt\protocol;
+
+class Signatures
+{
+    public const INIT = 0x01;
+    public const HELLO = 0x01;
+    public const GOODBYE = 0x02;
+    public const ACK_FAILURE = 0x0E;
+    public const RESET = 0x0F;
+
+    public const RUN = 0x10;
+    public const BEGIN = 0x11;
+    public const COMMIT = 0x12;
+    public const ROLLBACK = 0x13;
+
+    public const DISCARD = 0x2F;
+    public const DISCARD_ALL = 0x2F;
+
+    public const PULL_ALL = 0x3F;
+    public const PULL = 0x3F;
+
+    public const ROUTE = 0x66;
+
+    public const SUCCESS = 0x70;
+    public const RECORD = 0x71;
+    public const IGNORED = 0x7E;
+    public const FAILURE = 0x7F;
+}

--- a/src/protocol/V4_3.php
+++ b/src/protocol/V4_3.php
@@ -28,21 +28,10 @@ class V4_3 extends V4_2
      */
     public function route(...$args): array
     {
-        if (count($args) != 3) {
+        if (count($args) !== 3) {
             throw new PackException('Wrong arguments count');
         }
 
-        $this->write($this->packer->pack(0x66, (object)$args[0], $args[1], $args[2]));
-        $message = $this->read($signature);
-
-        if ($signature === self::FAILURE) {
-            throw new MessageException($message['message'], $message['code']);
-        }
-
-        if ($signature == self::IGNORED) {
-            throw new IgnoredException('ROUTE message IGNORED. Server in FAILED or INTERRUPTED state.');
-        }
-
-        return $message;
+        return $this->io(Signatures::ROUTE, (object)$args[0], $args[1], $args[2]);
     }
 }

--- a/tests/protocol/ServerState/HasMessageRequests.php
+++ b/tests/protocol/ServerState/HasMessageRequests.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState;
+
+use Bolt\protocol\ServerState\IServerState;
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\Signatures;
+use function array_search;
+use function json_encode;
+
+trait HasMessageRequests
+{
+    protected array $messages = [
+        'INIT/HELLO' => Signatures::INIT,
+        'GOODBYE' => Signatures::GOODBYE,
+        'ACK_FAILURE' => Signatures::ACK_FAILURE,
+        'RESET' => Signatures::RESET,
+        'RUN' => Signatures::RUN,
+        'BEGIN' => Signatures::BEGIN,
+        'COMMIT' => Signatures::COMMIT,
+        'ROLLBACK' => Signatures::ROLLBACK,
+        'DISCARD(_ALL)' => Signatures::DISCARD,
+        'PULL(_ALL)' => Signatures::PULL_ALL,
+        'ROUTE' => Signatures::ROUTE,
+    ];
+
+    protected array $responses = [
+        'SUCCESS' => Signatures::SUCCESS,
+        'RECORD' => Signatures::RECORD,
+        'IGNORED' => Signatures::IGNORED,
+        'FAILURE' => Signatures::FAILURE,
+        'NULL' => null
+    ];
+
+    private array $signals = [
+        '<INTERRUPT>' => ServerStateSignal::INTERRUPT,
+        '<DISCONNECT>' => ServerStateSignal::DISCONNECT,
+    ];
+
+    protected IServerState $state;
+
+    /**
+     * @param array<array{message: int, response: int, state: int}> $overrides
+     *
+     * @return array
+     */
+    public function generateMessageData(array $overrides): array
+    {
+        $tbr = [];
+        foreach ($this->messages as $messageName => $message) {
+            foreach ($this->responses as $responseName => $response) {
+                $tbr[$messageName . ' ' . $responseName] = [$message, $response, ServerStates::UNKNOWN, []];
+            }
+        }
+
+        foreach ($overrides as $override) {
+            $pos = array_search($override['message'], $this->messages, true);
+            $pos .= ' ' . array_search($override['response'], $this->responses, true);
+            if ($override['data'] ?? false) {
+                $pos .= ' '.json_encode($override['data'], JSON_THROW_ON_ERROR);
+            }
+
+            $tbr[$pos] = [$override['message'], $override['response'], $override['state'], $override['data'] ?? []];
+        }
+
+        return $tbr;
+    }
+
+    /**
+     * @param int $currentState
+     * @param array<array{signal: int, state: int}> $overrides
+     *
+     * @return array
+     */
+    public function generateSignalData(int $currentState, array $overrides): array
+    {
+        $tbr = [];
+        foreach ($this->signals as $signalName => $signal) {
+            $tbr[$signalName] = [$signal, $currentState];
+        }
+
+        foreach ($overrides as $override) {
+            $pos = array_search($override['signal'], $this->signals, true);
+
+            $tbr[$pos] = [$override['signal'],  $override['state']];
+        }
+
+        return $tbr;
+    }
+
+    /**
+     * @dataProvider messageMaps
+     */
+    public function testTransitionFromMessage(int $message, ?int $response, int $expected, array $data): void
+    {
+        $this->assertEquals($expected, $this->state->transitionFromMessage($message, $response, $data));
+    }
+
+    /**
+     * @dataProvider signalMaps
+     */
+    public function testTransitionFromSignal(int $signal, ?int $expected): void
+    {
+        $this->assertEquals($expected, $this->state->transitionFromSignal($signal));
+    }
+
+    abstract public function messageMaps(): array;
+
+    abstract public function signalMaps(): array;
+
+    public function testAfterHandshake(): void
+    {
+        $this->assertEquals(ServerStates::UNKNOWN, $this->state->transitionAfterHandshake(true));
+        $this->assertEquals(ServerStates::UNKNOWN, $this->state->transitionAfterHandshake(false));
+    }
+}

--- a/tests/protocol/ServerState/V1/ConnectedTest.php
+++ b/tests/protocol/ServerState/V1/ConnectedTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Connected;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class ConnectedTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Connected();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::INIT, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::INIT, 'response' => Signatures::FAILURE, 'state' => ServerStates::DEFUNCT],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V1/DefunctTest.php
+++ b/tests/protocol/ServerState/V1/DefunctTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\V1\Defunct;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class DefunctTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Defunct();
+    }
+
+    public function messageMaps(): array
+    {
+        $tbr = [];
+        foreach ($this->messages as $messageString => $message) {
+            foreach ($this->responses as $responseString => $response) {
+                $tbr[$messageString . ' ' . $responseString] = [$message, $response, ServerStates::DEFUNCT, []];
+            }
+        }
+
+        return $tbr;
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::DEFUNCT, []);
+    }
+}

--- a/tests/protocol/ServerState/V1/DisconnectedTest.php
+++ b/tests/protocol/ServerState/V1/DisconnectedTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Disconnected;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class DisconnectedTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Disconnected();
+    }
+
+    public function testAfterHandshake(): void
+    {
+        $this->assertEquals(ServerStates::CONNECTED, $this->state->transitionAfterHandshake(true));
+        $this->assertEquals(ServerStates::DEFUNCT, $this->state->transitionAfterHandshake(false));
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DISCONNECTED],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::DISCONNECTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V1/FailedTest.php
+++ b/tests/protocol/ServerState/V1/FailedTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Connected;
+use Bolt\protocol\ServerState\V1\Failed;
+use Bolt\protocol\ServerState\V1\Ready;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class FailedTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Failed();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => Signatures::IGNORED, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::IGNORED, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::IGNORED, 'state' => ServerStates::INTERRUPTED],
+            ['message' => Signatures::ACK_FAILURE, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::ACK_FAILURE, 'response' => Signatures::FAILURE, 'state' => ServerStates::DEFUNCT],
+            ['message' => Signatures::RESET, 'response' => Signatures::IGNORED, 'state' => ServerStates::UNKNOWN]
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V1/InterruptedTest.php
+++ b/tests/protocol/ServerState/V1/InterruptedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Interrupted;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class InterruptedTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Interrupted();
+    }
+
+    public function messageMaps(): array
+    {
+        $tbr = [];
+        foreach ($this->messages as $messageString => $message) {
+            foreach ($this->responses as $responseString => $response) {
+                $tbr[$messageString . ' ' . $responseString] = [$message, $response, ServerStates::INTERRUPTED, []];
+            }
+        }
+
+        $tbr['RESET SUCCESS'] = [Signatures::RESET, Signatures::SUCCESS, ServerStates::READY, []];
+        $tbr['RESET FAILURE'] = [Signatures::RESET, Signatures::FAILURE, ServerStates::DEFUNCT, []];
+
+        return $tbr;
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::INTERRUPTED, [
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED],
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V1/ReadyTest.php
+++ b/tests/protocol/ServerState/V1/ReadyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Connected;
+use Bolt\protocol\ServerState\V1\Ready;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class ReadyTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Ready();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::STREAMING],
+            ['message' => Signatures::RUN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V1/StreamingTest.php
+++ b/tests/protocol/ServerState/V1/StreamingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V1;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V1\Ready;
+use Bolt\protocol\ServerState\V1\Streaming;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class StreamingTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Streaming();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::RECORD, 'state' => ServerStates::STREAMING],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V3/FailedTest.php
+++ b/tests/protocol/ServerState/V3/FailedTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V3\Failed;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class FailedTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Failed();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => null, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => null, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => null, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::RUN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::RUN, 'response' => Signatures::IGNORED, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::IGNORED, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::IGNORED, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::RUN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::RUN, 'response' => Signatures::RECORD, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::RECORD, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::RECORD, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::GOODBYE, 'response' => null, 'state' => ServerStates::DEFUNCT],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V3/ReadyTest.php
+++ b/tests/protocol/ServerState/V3/ReadyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V3\Ready;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class ReadyTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Ready();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::STREAMING],
+            ['message' => Signatures::RUN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::BEGIN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::TX_READY],
+            ['message' => Signatures::BEGIN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::GOODBYE, 'response' => null, 'state' => ServerStates::DEFUNCT],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V3/TxReadyTest.php
+++ b/tests/protocol/ServerState/V3/TxReadyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V3\TxReady;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class TxReadyTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new TxReady();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::TX_STREAMING],
+            ['message' => Signatures::RUN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::COMMIT, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::COMMIT, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::ROLLBACK, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY],
+            ['message' => Signatures::ROLLBACK, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::GOODBYE, 'response' => null, 'state' => ServerStates::DEFUNCT],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V3/TxStreamingTest.php
+++ b/tests/protocol/ServerState/V3/TxStreamingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\ServerStateSignal;
+use Bolt\protocol\ServerState\V3\TxStreaming;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\HasMessageRequests;
+use PHPUnit\Framework\TestCase;
+
+class TxStreamingTest extends TestCase
+{
+    use HasMessageRequests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new TxStreaming();
+    }
+
+    public function messageMaps(): array
+    {
+        return $this->generateMessageData([
+            ['message' => Signatures::RUN, 'response' => Signatures::SUCCESS, 'state' => ServerStates::TX_STREAMING],
+            ['message' => Signatures::RUN, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::TX_READY],
+            ['message' => Signatures::PULL_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::SUCCESS, 'state' => ServerStates::TX_READY],
+            ['message' => Signatures::DISCARD_ALL, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED],
+            ['message' => Signatures::GOODBYE, 'response' => null, 'state' => ServerStates::DEFUNCT],
+            ['message' => Signatures::RESET, 'response' => null, 'state' => ServerStates::UNKNOWN],
+        ]);
+    }
+
+    public function signalMaps(): array
+    {
+        return $this->generateSignalData(ServerStates::CONNECTED, [
+            ['signal' => ServerStateSignal::DISCONNECT, 'state' => ServerStates::DEFUNCT],
+            ['signal' => ServerStateSignal::INTERRUPT, 'state' => ServerStates::INTERRUPTED]
+        ]);
+    }
+}

--- a/tests/protocol/ServerState/V4_0/StreamingTest.php
+++ b/tests/protocol/ServerState/V4_0/StreamingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V4_0;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\V4_0\Streaming;
+use Bolt\protocol\Signatures;
+
+class StreamingTest extends \Bolt\tests\protocol\ServerState\V1\StreamingTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Streaming();
+    }
+
+    public function generateMessageData(array $overrides): array
+    {
+        array_push(
+            $overrides,
+            [
+                'message'  => Signatures::PULL,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::STREAMING,
+                'data' => ['has_more' => true],
+            ],
+            [
+                'message'  => Signatures::PULL,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::READY,
+                'data' => ['has_more' => false],
+            ],
+            [
+                'message'  => Signatures::DISCARD,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::STREAMING,
+                'data' => ['has_more' => true],
+            ],
+            [
+                'message'  => Signatures::DISCARD,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::READY,
+                'data' => ['has_more' => false],
+            ]
+        );
+
+        return parent::generateMessageData($overrides);
+    }
+}

--- a/tests/protocol/ServerState/V4_0/TxStreamingTest.php
+++ b/tests/protocol/ServerState/V4_0/TxStreamingTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V4_0;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\V4_0\TxStreaming;
+use Bolt\protocol\ServerState\V4_3\Ready;
+use Bolt\protocol\Signatures;
+
+class TxStreamingTest extends \Bolt\tests\protocol\ServerState\V3\TxStreamingTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new TxStreaming();
+    }
+
+    public function testFirstRun(): void
+    {
+        $state = $this->state->transitionFromMessage(Signatures::RUN, Signatures::SUCCESS);
+        $this->assertEquals(ServerStates::TX_STREAMING, $state);
+
+        $state = $this->state->transitionFromMessage(Signatures::PULL, Signatures::SUCCESS, ['has_more' => true]);
+        $this->assertEquals(ServerStates::TX_STREAMING, $state);
+
+        $state = $this->state->transitionFromMessage(Signatures::PULL, Signatures::SUCCESS, ['has_more' => false]);
+        $this->assertEquals(ServerStates::TX_STREAMING, $state);
+
+        $state = $this->state->transitionFromMessage(Signatures::RUN, Signatures::SUCCESS);
+        $this->assertEquals(ServerStates::TX_STREAMING, $state);
+
+
+        $state = $this->state->transitionFromMessage(Signatures::PULL, Signatures::SUCCESS, ['has_more' => false]);
+        $this->assertEquals(ServerStates::TX_STREAMING, $state);
+
+
+        $state = $this->state->transitionFromMessage(Signatures::PULL, Signatures::SUCCESS, ['has_more' => false]);
+        $this->assertEquals(ServerStates::TX_READY, $state);
+    }
+
+    public function generateMessageData(array $overrides): array
+    {
+        array_push(
+            $overrides,
+            [
+                'message'  => Signatures::PULL,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::TX_STREAMING,
+                'data' => ['has_more' => true],
+            ],
+            [
+                'message'  => Signatures::PULL,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::TX_READY,
+                'data' => ['has_more' => false],
+            ],
+            [
+                'message'  => Signatures::DISCARD,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::TX_STREAMING,
+                'data' => ['has_more' => true],
+            ],
+            [
+                'message'  => Signatures::DISCARD,
+                'response' => Signatures::SUCCESS,
+                'state'    => ServerStates::TX_READY,
+                'data' => ['has_more' => false],
+            ]
+        );
+
+        return parent::generateMessageData($overrides);
+    }
+}

--- a/tests/protocol/ServerState/V4_3/ReadTest.php
+++ b/tests/protocol/ServerState/V4_3/ReadTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bolt\tests\protocol\ServerState\V4_3;
+
+use Bolt\protocol\ServerState\ServerStates;
+use Bolt\protocol\ServerState\V4_3\Ready;
+use Bolt\protocol\Signatures;
+use Bolt\tests\protocol\ServerState\V3\ReadyTest;
+
+class ReadTest extends ReadyTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->state = new Ready();
+    }
+
+    public function generateMessageData(array $overrides): array
+    {
+        $overrides[] = ['message' => Signatures::ROUTE, 'response' => Signatures::SUCCESS, 'state' => ServerStates::READY];
+        $overrides[] = ['message' => Signatures::ROUTE, 'response' => Signatures::FAILURE, 'state' => ServerStates::FAILED];
+
+        return parent::generateMessageData($overrides);
+    }
+}


### PR DESCRIPTION
Hello,

Thank you for your patience.

I was finally able to implement and use the server states in the bolt protocol. Some core design considerations:
 - to me, the server states is a state machine. This means each state can only have a few select paths it can go to, which screamed OOP to me
 - I tested every possible path for each of the server states to make sure it works
 - In order to smoothly transition between states, I needed the request and response signature + data in some cases. To avoid code duplication, I've put it all into a single io method, which packs the request and interprets the response.