### PR TITLE
added pipeline versions of methods

### DIFF
--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -141,7 +141,7 @@ abstract class AProtocol
         } elseif (end($output) instanceof IgnoredException) {
             $this->serverState->set(ServerState::INTERRUPTED);
         } else {
-            $this->serverState->set($this->serverState->is(ServerState::READY, ServerState::STREAMING) ? ServerState::READY : ServerState::TX_READY);
+            $this->serverState->set($this->serverState->get() == ServerState::READY || $this->serverState->get() == ServerState::STREAMING ? ServerState::READY : ServerState::TX_READY);
         }
 
         return $output;

--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -146,4 +146,14 @@ abstract class AProtocol
 
         return $output;
     }
+
+    /**
+     * @throws Exception
+     */
+    protected function flushPipelineResponse()
+    {
+        if (count($this->pipelinedMessages) > 0) {
+            $this->fetchPipelineResponse();
+        }
+    }
 }

--- a/src/protocol/AProtocol.php
+++ b/src/protocol/AProtocol.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\protocol;
 
+use Bolt\error\IgnoredException;
+use Bolt\error\MessageException;
 use Bolt\helpers\ServerState;
 use Bolt\PackStream\{IPacker, IUnpacker};
 use Bolt\connection\IConnection;
@@ -26,6 +28,8 @@ abstract class AProtocol
     protected IConnection $connection;
 
     public ServerState $serverState;
+
+    protected array $pipelinedMessages = [];
 
     /**
      * AProtocol constructor.
@@ -91,5 +95,55 @@ abstract class AProtocol
         }
 
         trigger_error('Protocol version class name is not valid', E_USER_ERROR);
+    }
+
+    /**
+     * Fetch all responses from pipelined (executed) messages
+     * @return array
+     * @throws Exception
+     */
+    public function fetchPipelineResponse(): array
+    {
+        $this->serverState->is(ServerState::READY, ServerState::TX_READY, ServerState::STREAMING, ServerState::TX_STREAMING);
+
+        $output = [];
+
+        foreach ($this->pipelinedMessages as $message) {
+            $response = $this->read($signature);
+
+            switch ($signature) {
+                case self::RECORD:
+                    $records = [$response];
+                    do {
+                        $record = $this->read($signature);
+                        $records[] = $record;
+                    } while ($signature == self::RECORD);
+                    $output[] = $records;
+                    break;
+
+                case self::FAILURE:
+                    $output[] = new MessageException($response['message'], $response['code']);
+                    break;
+
+                case self::IGNORED:
+                    $output[] = new IgnoredException($message);
+                    break;
+
+                default:
+                    $output[] = $response;
+            }
+        }
+
+        $this->pipelinedMessages = [];
+
+        if (end($output) instanceof MessageException) {
+            $this->serverState->set(ServerState::FAILED);
+        } elseif (end($output) instanceof IgnoredException) {
+            $this->serverState->set(ServerState::INTERRUPTED);
+        } else {
+            $this->serverState->set($this->serverState->is(ServerState::READY, ServerState::STREAMING) ? ServerState::READY : ServerState::TX_READY);
+        }
+
+        return $output;
     }
 }

--- a/src/protocol/V1.php
+++ b/src/protocol/V1.php
@@ -63,13 +63,9 @@ class V1 extends AProtocol
      */
     public function run(...$args): array
     {
-        $this->serverState->is(ServerState::READY);
+        $this->_run(...$args);
+        array_pop($this->pipelinedMessages);
 
-        if (empty($args)) {
-            throw new PackException('Wrong arguments count');
-        }
-
-        $this->write($this->packer->pack(0x10, $args[0], (object)($args[1] ?? [])));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -83,8 +79,23 @@ class V1 extends AProtocol
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set(ServerState::STREAMING);
         return $message;
+    }
+
+    /**
+     * Pipelined version of RUN
+     */
+    public function _run(...$args)
+    {
+        $this->serverState->is(ServerState::READY);
+
+        if (empty($args)) {
+            throw new PackException('Wrong arguments count');
+        }
+
+        $this->write($this->packer->pack(0x10, $args[0], (object)($args[1] ?? [])));
+        $this->pipelinedMessages[] = 'run';
+        $this->serverState->set(ServerState::STREAMING);
     }
 
     /**
@@ -98,9 +109,8 @@ class V1 extends AProtocol
      */
     public function pullAll(...$args): array
     {
-        $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
-
-        $this->write($this->packer->pack(0x3F));
+        $this->_pullAll(...$args);
+        array_pop($this->pipelinedMessages);
 
         $output = [];
         do {
@@ -119,8 +129,20 @@ class V1 extends AProtocol
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set($this->serverState->get() === ServerState::STREAMING ? ServerState::READY : ServerState::TX_READY);
         return $output;
+    }
+
+    /**
+     * Pipelined version of PULL_ALL
+     */
+    public function _pullAll(...$args)
+    {
+        $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
+        $this->write($this->packer->pack(0x3F));
+        $this->pipelinedMessages[] = 'pull_all';
+        if ($this->serverState->is(ServerState::STREAMING)) {
+            $this->serverState->set(ServerState::READY);
+        }
     }
 
     /**
@@ -134,9 +156,9 @@ class V1 extends AProtocol
      */
     public function discardAll(...$args): array
     {
-        $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
+        $this->_discardAll(...$args);
+        array_pop($this->pipelinedMessages);
 
-        $this->write($this->packer->pack(0x2F));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -150,8 +172,20 @@ class V1 extends AProtocol
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set($this->serverState->get() === ServerState::STREAMING ? ServerState::READY : ServerState::TX_READY);
         return $message;
+    }
+
+    /**
+     * Pipelined version of DISCARD_ALL
+     */
+    public function _discardAll(...$args)
+    {
+        $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
+        $this->write($this->packer->pack(0x2F));
+        $this->pipelinedMessages[] = 'discard_all';
+        if ($this->serverState->is(ServerState::STREAMING)) {
+            $this->serverState->set(ServerState::READY);
+        }
     }
 
     /**
@@ -186,7 +220,9 @@ class V1 extends AProtocol
      */
     public function reset(): array
     {
-        $this->write($this->packer->pack(0x0F));
+        $this->_reset();
+        array_pop($this->pipelinedMessages);
+
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -195,7 +231,16 @@ class V1 extends AProtocol
             throw new MessageException($message['message'], $message['code']);
         }
 
-        $this->serverState->set(ServerState::READY);
         return $message;
+    }
+
+    /**
+     * Pipelined version of RESET
+     */
+    public function _reset()
+    {
+        $this->write($this->packer->pack(0x0F));
+        $this->pipelinedMessages[] = 'reset';
+        $this->serverState->set(ServerState::READY);
     }
 }

--- a/src/protocol/V1.php
+++ b/src/protocol/V1.php
@@ -142,7 +142,7 @@ class V1 extends AProtocol
         $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
         $this->write($this->packer->pack(0x3F));
         $this->pipelinedMessages[] = 'pull_all';
-        if ($this->serverState->is(ServerState::STREAMING)) {
+        if ($this->serverState->get() == ServerState::STREAMING) {
             $this->serverState->set(ServerState::READY);
         }
     }
@@ -186,7 +186,7 @@ class V1 extends AProtocol
         $this->serverState->is(ServerState::STREAMING, ServerState::TX_STREAMING);
         $this->write($this->packer->pack(0x2F));
         $this->pipelinedMessages[] = 'discard_all';
-        if ($this->serverState->is(ServerState::STREAMING)) {
+        if ($this->serverState->get() == ServerState::STREAMING) {
             $this->serverState->set(ServerState::READY);
         }
     }

--- a/src/protocol/V1.php
+++ b/src/protocol/V1.php
@@ -63,6 +63,7 @@ class V1 extends AProtocol
      */
     public function run(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_run(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -109,6 +110,7 @@ class V1 extends AProtocol
      */
     public function pullAll(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_pullAll(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -156,6 +158,7 @@ class V1 extends AProtocol
      */
     public function discardAll(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_discardAll(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -220,6 +223,7 @@ class V1 extends AProtocol
      */
     public function reset(): array
     {
+        $this->flushPipelineResponse();
         $this->_reset();
         array_pop($this->pipelinedMessages);
 

--- a/src/protocol/V3.php
+++ b/src/protocol/V3.php
@@ -69,18 +69,9 @@ class V3 extends V2
      */
     public function run(...$args): array
     {
-        $this->serverState->is(ServerState::READY, ServerState::TX_READY);
+        $this->_run(...$args);
+        array_pop($this->pipelinedMessages);
 
-        if (empty($args)) {
-            throw new PackException('Wrong arguments count');
-        }
-
-        $this->write($this->packer->pack(
-            0x10,
-            $args[0],
-            (object)($args[1] ?? []),
-            (object)($args[2] ?? [])
-        ));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -93,8 +84,29 @@ class V3 extends V2
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set($this->serverState->get() === ServerState::READY ? ServerState::STREAMING : ServerState::TX_STREAMING);
         return $message;
+    }
+
+    /**
+     * Pipelined version of RUN
+     */
+    public function _run(...$args)
+    {
+        $this->serverState->is(ServerState::READY, ServerState::TX_READY, ServerState::TX_STREAMING);
+
+        if (empty($args)) {
+            throw new PackException('Wrong arguments count');
+        }
+
+        $this->write($this->packer->pack(
+            0x10,
+            $args[0],
+            (object)($args[1] ?? []),
+            (object)($args[2] ?? [])
+        ));
+
+        $this->pipelinedMessages[] = 'run';
+        $this->serverState->set($this->serverState->is(ServerState::READY) ? ServerState::STREAMING : ServerState::TX_STREAMING);
     }
 
     /**
@@ -108,9 +120,9 @@ class V3 extends V2
      */
     public function begin(...$args): array
     {
-        $this->serverState->is(ServerState::READY);
+        $this->_begin(...$args);
+        array_pop($this->pipelinedMessages);
 
-        $this->write($this->packer->pack(0x11, (object)($args[0] ?? [])));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -123,8 +135,18 @@ class V3 extends V2
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set(ServerState::TX_READY);
         return $message;
+    }
+
+    /**
+     * Pipelined version of BEGIN
+     */
+    public function _begin(...$args)
+    {
+        $this->serverState->is(ServerState::READY);
+        $this->write($this->packer->pack(0x11, (object)($args[0] ?? [])));
+        $this->pipelinedMessages[] = 'begin';
+        $this->serverState->set(ServerState::TX_READY);
     }
 
     /**
@@ -137,9 +159,9 @@ class V3 extends V2
      */
     public function commit(): array
     {
-        $this->serverState->is(ServerState::TX_READY);
+        $this->_commit();
+        array_pop($this->pipelinedMessages);
 
-        $this->write($this->packer->pack(0x12));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -152,8 +174,18 @@ class V3 extends V2
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set(ServerState::READY);
         return $message;
+    }
+
+    /**
+     * Pipelined version of COMMIT
+     */
+    public function _commit()
+    {
+        $this->serverState->is(ServerState::TX_READY, ServerState::TX_STREAMING);
+        $this->write($this->packer->pack(0x12));
+        $this->pipelinedMessages[] = 'commit';
+        $this->serverState->set(ServerState::READY);
     }
 
     /**
@@ -166,9 +198,9 @@ class V3 extends V2
      */
     public function rollback(): array
     {
-        $this->serverState->is(ServerState::TX_READY);
+        $this->_rollback();
+        array_pop($this->pipelinedMessages);
 
-        $this->write($this->packer->pack(0x13));
         $message = $this->read($signature);
 
         if ($signature == self::FAILURE) {
@@ -181,8 +213,18 @@ class V3 extends V2
             throw new IgnoredException(__FUNCTION__);
         }
 
-        $this->serverState->set(ServerState::READY);
         return $message;
+    }
+
+    /**
+     * Pipelined version of ROLLBACK
+     */
+    public function _rollback()
+    {
+        $this->serverState->is(ServerState::TX_READY, ServerState::TX_STREAMING);
+        $this->write($this->packer->pack(0x13));
+        $this->pipelinedMessages[] = 'rollback';
+        $this->serverState->set(ServerState::READY);
     }
 
     /**

--- a/src/protocol/V3.php
+++ b/src/protocol/V3.php
@@ -107,7 +107,7 @@ class V3 extends V2
         ));
 
         $this->pipelinedMessages[] = 'run';
-        $this->serverState->set($this->serverState->is(ServerState::READY) ? ServerState::STREAMING : ServerState::TX_STREAMING);
+        $this->serverState->set($this->serverState->get() == ServerState::READY ? ServerState::STREAMING : ServerState::TX_STREAMING);
     }
 
     /**

--- a/src/protocol/V3.php
+++ b/src/protocol/V3.php
@@ -69,6 +69,7 @@ class V3 extends V2
      */
     public function run(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_run(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -120,6 +121,7 @@ class V3 extends V2
      */
     public function begin(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_begin(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -159,6 +161,7 @@ class V3 extends V2
      */
     public function commit(): array
     {
+        $this->flushPipelineResponse();
         $this->_commit();
         array_pop($this->pipelinedMessages);
 
@@ -198,6 +201,7 @@ class V3 extends V2
      */
     public function rollback(): array
     {
+        $this->flushPipelineResponse();
         $this->_rollback();
         array_pop($this->pipelinedMessages);
 

--- a/src/protocol/V4.php
+++ b/src/protocol/V4.php
@@ -47,6 +47,7 @@ class V4 extends V3
      */
     public function pull(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_pull(...$args);
         array_pop($this->pipelinedMessages);
 
@@ -120,6 +121,7 @@ class V4 extends V3
      */
     public function discard(...$args): array
     {
+        $this->flushPipelineResponse();
         $this->_discard(...$args);
         array_pop($this->pipelinedMessages);
 

--- a/src/protocol/V4.php
+++ b/src/protocol/V4.php
@@ -28,6 +28,15 @@ class V4 extends V3
     }
 
     /**
+     * @inheritDoc
+     * @deprecated Renamed to PULL
+     */
+    public function _pullAll(...$args)
+    {
+        $this->_pull(...$args);
+    }
+
+    /**
      * Send PULL message
      * The PULL message requests data from the remainder of the result stream.
      *
@@ -89,6 +98,15 @@ class V4 extends V3
     public function discardAll(...$args): array
     {
         return $this->discard(...$args);
+    }
+
+    /**
+     * @inheritDoc
+     * @deprecated Renamed to DISCARD
+     */
+    public function _discardAll(...$args)
+    {
+        $this->_discard(...$args);
     }
 
     /**

--- a/src/protocol/V4.php
+++ b/src/protocol/V4.php
@@ -68,7 +68,7 @@ class V4 extends V3
         }
 
         if ($message['has_more'] ?? false) {
-            $this->serverState->set($this->serverState->is(ServerState::READY) ? ServerState::STREAMING : ServerState::TX_STREAMING);
+            $this->serverState->set($this->serverState->get() == ServerState::READY ? ServerState::STREAMING : ServerState::TX_STREAMING);
         }
 
         return $output;
@@ -89,7 +89,7 @@ class V4 extends V3
         $this->write($this->packer->pack(0x3F, $args[0]));
 
         $this->pipelinedMessages[] = 'pull';
-        $this->serverState->set($this->serverState->is(ServerState::STREAMING) ? ServerState::READY : ServerState::TX_READY);
+        $this->serverState->set($this->serverState->get() == ServerState::STREAMING ? ServerState::READY : ServerState::TX_READY);
     }
 
     /**
@@ -138,7 +138,7 @@ class V4 extends V3
         }
 
         if ($message['has_more'] ?? false) {
-            $this->serverState->set($this->serverState->is(ServerState::READY) ? ServerState::STREAMING : ServerState::TX_STREAMING);
+            $this->serverState->set($this->serverState->get() == ServerState::READY ? ServerState::STREAMING : ServerState::TX_STREAMING);
         }
 
         return $message;
@@ -159,6 +159,6 @@ class V4 extends V3
         $this->write($this->packer->pack(0x2F, $args[0]));
 
         $this->pipelinedMessages[] = 'discard';
-        $this->serverState->set($this->serverState->is(ServerState::STREAMING) ? ServerState::READY : ServerState::TX_READY);
+        $this->serverState->set($this->serverState->get() == ServerState::STREAMING ? ServerState::READY : ServerState::TX_READY);
     }
 }

--- a/tests/BoltTest.php
+++ b/tests/BoltTest.php
@@ -321,4 +321,26 @@ class BoltTest extends TestCase
         $this->assertInstanceOf(MessageException::class, $response[0]);
         $this->assertEmpty($response[1]);
     }
+
+    /**
+     * @depends testHello
+     * @param AProtocol $protocol
+     */
+    public function testPipelineFlush(AProtocol $protocol)
+    {
+        try {
+            $protocol->run('RETURN "abc" as str');
+            $res = $protocol->pullAll();
+            $this->assertEquals('abc', $res[0][0]);
+
+            $protocol->_run('CREATE (n:Test { param: 5 }) WITH n DELETE n');
+            $protocol->_pullAll();
+
+            $protocol->run('RETURN 2 as num');
+            $res = $protocol->pullAll();
+            $this->assertEquals(2, $res[0][0]);
+        } catch (Exception $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
+    }
 }

--- a/tests/BoltTest.php
+++ b/tests/BoltTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\tests;
 
 use Bolt\Bolt;
+use Bolt\error\MessageException;
 use Bolt\protocol\AProtocol;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -232,7 +233,7 @@ class BoltTest extends TestCase
                 $this->assertInstanceOf(\Bolt\structures\Node::class, $pull[0][0]);
                 $this->assertCount(count($data), $pull[0][0]->properties());
             } catch (Exception $e) {
-                $this->markTestIncomplete();
+                $this->markTestIncomplete($e->getMessage());
             }
         }
 
@@ -252,5 +253,72 @@ class BoltTest extends TestCase
 
         $this->expectException(Exception::class);
         $protocol->run('RETURN 1 as num');
+    }
+
+    /**
+     * @depends testHello
+     * @param AProtocol $protocol
+     */
+    public function testPipelineAutocommit(AProtocol $protocol)
+    {
+        try {
+            $protocol->_run('RETURN 1 AS num');
+            $protocol->_pullAll();
+            $response = $protocol->fetchPipelineResponse();
+        } catch (Exception $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
+
+        $this->assertCount(2, $response);
+        $this->assertEquals(1, $response[1][0][0]);
+        foreach ($response as $entry) {
+            if ($entry instanceof Exception) {
+                $this->markTestIncomplete($entry->getMessage());
+            }
+        }
+    }
+
+    /**
+     * @depends testHello
+     * @param AProtocol $protocol
+     */
+    public function testPipelineTransaction(AProtocol $protocol)
+    {
+        try {
+            $protocol->_begin();
+            $protocol->_run('RETURN 2 AS num');
+            $protocol->_run('RETURN "abc" AS str UNION RETURN "def" AS str');
+            $protocol->_discardAll();
+            $protocol->_rollback();
+            $response = $protocol->fetchPipelineResponse();
+        } catch (Exception $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
+
+        $this->assertCount(5, $response);
+        foreach ($response as $entry) {
+            if ($entry instanceof Exception) {
+                $this->markTestIncomplete($entry->getMessage());
+            }
+        }
+    }
+
+    /**
+     * @depends testHello
+     * @param AProtocol $protocol
+     */
+    public function testPipelineReset(AProtocol $protocol)
+    {
+        try {
+            $protocol->_run('RETURN 1 AS num');
+            $protocol->_reset();
+            $response = $protocol->fetchPipelineResponse();
+        } catch (Exception $e) {
+            $this->markTestIncomplete($e->getMessage());
+        }
+
+        $this->assertCount(2, $response);
+        $this->assertInstanceOf(MessageException::class, $response[0]);
+        $this->assertEmpty($response[1]);
     }
 }


### PR DESCRIPTION
Allowed methods for pipelining: run, pull, pull_all, discard, discard_all, begin, commit, rollback, reset

Each pipelined version use the same method name with `_` prefix.

To fetch all responses use `fetchPipelineResponse` method. If any of responses contains error the output array contains instance of MessageException or IgnoredException.

closing #99 