### PR TITLE
v5.3

### DIFF
--- a/.github/workflows/db.50.2204.yml
+++ b/.github/workflows/db.50.2204.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neo4j-version: ['5.1', '5.2', '5.3', '5.4', '5.5']
+        neo4j-version: ['5.4', '5.6', '5.8', '5.12']
         php-version: ['8.0', '8.1', '8.2']
 
     services:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ all available versions and keep up with protocol messages architecture and speci
 
 ## Version support
 
-We are trying to keep up and this library supports **Neo4j <= 5.7** with **Bolt <= 5.2**.
+We are trying to keep up and this library supports **Bolt <= 5.3**.
 
 https://www.neo4j.com/docs/bolt/current/bolt-compatibility/
 
@@ -33,7 +33,7 @@ Not all new features are implement backwards and this readme is updated to lates
 - [sockets](https://www.php.net/manual/en/book.sockets.php) (optional) - Required when you use Socket connection class
 - [openssl](https://www.php.net/manual/en/book.openssl.php) (optional) - Required when you use StreamSocket connection
   class with enabled SSL
-- [phpunit](https://phpunit.de/) >= 9 (development)
+- [phpunit](https://phpunit.de/) (development)
 
 ## Installation
 

--- a/src/protocol/V5_3.php
+++ b/src/protocol/V5_3.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bolt\protocol;
+
+/**
+ * Class Protocol version 5.3
+ *
+ * @author Michal Stefanak
+ * @link https://github.com/neo4j-php/Bolt
+ * @see https://www.neo4j.com/docs/bolt/current/bolt/message/
+ * @package Bolt\protocol
+ */
+class V5_3 extends AProtocol
+{
+    use \Bolt\protocol\v5\AvailableStructures;
+
+    use \Bolt\protocol\v1\ResetMessage;
+
+    use \Bolt\protocol\v3\RunMessage;
+    use \Bolt\protocol\v3\BeginMessage;
+    use \Bolt\protocol\v3\CommitMessage;
+    use \Bolt\protocol\v3\RollbackMessage;
+    use \Bolt\protocol\v3\GoodbyeMessage;
+
+    use \Bolt\protocol\v4\PullMessage;
+    use \Bolt\protocol\v4\DiscardMessage;
+
+    use \Bolt\protocol\v4_4\RouteMessage;
+
+    use \Bolt\protocol\v5_1\LogonMessage;
+    use \Bolt\protocol\v5_1\LogoffMessage;
+
+    use \Bolt\protocol\v5_3\HelloMessage;
+}

--- a/src/protocol/v1/ResetMessage.php
+++ b/src/protocol/v1/ResetMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v1;
 
-use Bolt\protocol\{ServerState, Response, V1, V2, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V1, V2, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait ResetMessage
@@ -14,7 +14,7 @@ trait ResetMessage
      * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-reset
      * @throws BoltException
      */
-    public function reset(): V1|V2|V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function reset(): V1|V2|V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->write($this->packer->pack(0x0F));
         $this->pipelinedMessages[] = __FUNCTION__;

--- a/src/protocol/v3/BeginMessage.php
+++ b/src/protocol/v3/BeginMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v3;
 
-use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait BeginMessage
@@ -14,7 +14,7 @@ trait BeginMessage
      * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-begin
      * @throws BoltException
      */
-    public function begin(array $extra = []): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function begin(array $extra = []): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::READY);
         $this->write($this->packer->pack(0x11, (object)$extra));

--- a/src/protocol/v3/CommitMessage.php
+++ b/src/protocol/v3/CommitMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v3;
 
-use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait CommitMessage
@@ -14,7 +14,7 @@ trait CommitMessage
      * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-commit
      * @throws BoltException
      */
-    public function commit(): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function commit(): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::TX_READY, ServerState::TX_STREAMING);
         $this->write($this->packer->pack(0x12));

--- a/src/protocol/v3/RollbackMessage.php
+++ b/src/protocol/v3/RollbackMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v3;
 
-use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait RollbackMessage
@@ -14,7 +14,7 @@ trait RollbackMessage
      * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-rollback
      * @throws BoltException
      */
-    public function rollback(): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function rollback(): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::TX_READY, ServerState::TX_STREAMING);
         $this->write($this->packer->pack(0x13));

--- a/src/protocol/v3/RunMessage.php
+++ b/src/protocol/v3/RunMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v3;
 
-use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait RunMessage
@@ -14,7 +14,7 @@ trait RunMessage
      * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-run
      * @throws BoltException
      */
-    public function run(string $query, array $parameters = [], array $extra = []): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function run(string $query, array $parameters = [], array $extra = []): V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::READY, ServerState::TX_READY, ServerState::STREAMING, ServerState::TX_STREAMING);
 

--- a/src/protocol/v4/DiscardMessage.php
+++ b/src/protocol/v4/DiscardMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v4;
 
-use Bolt\protocol\{ServerState, Response, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait DiscardMessage
@@ -15,7 +15,7 @@ trait DiscardMessage
      * @param array $extra [n::Integer, qid::Integer]
      * @throws BoltException
      */
-    public function discard(array $extra = []): V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function discard(array $extra = []): V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::READY, ServerState::TX_READY, ServerState::STREAMING, ServerState::TX_STREAMING);
 

--- a/src/protocol/v4/PullMessage.php
+++ b/src/protocol/v4/PullMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v4;
 
-use Bolt\protocol\{ServerState, Response, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait PullMessage
@@ -15,7 +15,7 @@ trait PullMessage
      * @param array $extra [n::Integer, qid::Integer]
      * @throws BoltException
      */
-    public function pull(array $extra = []): V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1
+    public function pull(array $extra = []): V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::READY, ServerState::TX_READY, ServerState::STREAMING, ServerState::TX_STREAMING);
 

--- a/src/protocol/v4_4/RouteMessage.php
+++ b/src/protocol/v4_4/RouteMessage.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\protocol\v4_4;
 
-use Bolt\protocol\{ServerState, Response, V4_4, V5, V5_1};
+use Bolt\protocol\{ServerState, Response, V4_4, V5, V5_1, V5_2, V5_3};
 use Bolt\error\BoltException;
 
 trait RouteMessage
@@ -15,7 +15,7 @@ trait RouteMessage
      * @param array $extra [db::String, imp_user::String]
      * @throws BoltException
      */
-    public function route(array $routing, array $bookmarks = [], array $extra = []): V4_4|V5|V5_1
+    public function route(array $routing, array $bookmarks = [], array $extra = []): V4_4|V5|V5_1|V5_2|V5_3
     {
         $this->serverState->is(ServerState::READY);
         $this->write($this->packer->pack(0x66, (object)$routing, $bookmarks, (object)$extra));

--- a/src/protocol/v5_3/HelloMessage.php
+++ b/src/protocol/v5_3/HelloMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\protocol\v5_3;
+
+use Bolt\protocol\Response;
+use Bolt\error\BoltException;
+
+trait HelloMessage
+{
+    use \Bolt\protocol\v5_1\HelloMessage {
+        \Bolt\protocol\v5_1\HelloMessage::hello as __hello;
+    }
+
+    /**
+     * Send HELLO message
+     * The HELLO message request the connection to be authorized for use with the remote database.
+     *
+     * @link https://www.neo4j.com/docs/bolt/current/bolt/message/#messages-hello
+     * @param array $extra Use \Bolt\helpers\Auth to generate appropiate array
+     * @throws BoltException
+     */
+    public function hello(array $extra = []): Response
+    {
+        $extra['bolt_agent'] = [
+            'product' => 'php-bolt/' . \Composer\InstalledVersions::getPrettyVersion('stefanak-michal/bolt'),
+            'platform' => php_uname(),
+            'language' => 'PHP/' . phpversion(),
+            'language_details' => 'null'
+        ];
+
+        return $this->__hello($extra);
+    }
+}

--- a/tests/ATest.php
+++ b/tests/ATest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\tests;
 
-use Bolt\protocol\{AProtocol, Response, V1, V2, V3, V4, V4_1, V4_2, V4_3, V4_4, V5, V5_1};
+use Bolt\protocol\{AProtocol, Response};
 use Bolt\helpers\Auth;
 
 /**
@@ -28,17 +28,71 @@ class ATest extends \PHPUnit\Framework\TestCase
             $GLOBALS['NEO_PORT'] = $port;
     }
 
-    protected function sayHello(AProtocol|V1|V2|V3|V4|V4_1|V4_2|V4_3|V4_4|V5|V5_1 $protocol, string $name, string $password)
+    /**
+     * Unified way how to call init/hello/logon for tests
+     * @param AProtocol $protocol
+     * @param string $name
+     * @param string $password
+     */
+    protected function sayHello(AProtocol $protocol, string $name, string $password)
     {
-        if (version_compare($protocol->getVersion(), '5.1', '<')) {
-            $this->assertEquals(Response::SIGNATURE_SUCCESS, $protocol->hello(Auth::basic($name, $password))->getSignature());
-        } else {
+        if (method_exists($protocol, 'init')) {
+            $this->assertEquals(Response::SIGNATURE_SUCCESS, $protocol->init(Auth::$defaultUserAgent, [
+                'scheme' => 'basic',
+                'principal' => $name,
+                'credentials' => $password
+            ])->getSignature());
+        } elseif (method_exists($protocol, 'logon')) {
             $this->assertEquals(Response::SIGNATURE_SUCCESS, $protocol->hello()->getSignature());
             $this->assertEquals(Response::SIGNATURE_SUCCESS, $protocol->logon([
                 'scheme' => 'basic',
                 'principal' => $name,
                 'credentials' => $password
             ])->getSignature());
+        } else {
+            $this->assertEquals(Response::SIGNATURE_SUCCESS, $protocol->hello(Auth::basic($name, $password))->getSignature());
         }
+    }
+
+    /**
+     * Choose the right bolt version by Neo4j version
+     * Neo4j version is received by HTTP request on browser port
+     * @param string|null $url
+     * @return float|int
+     */
+    protected function getCompatibleBoltVersion(string $url = null): float|int
+    {
+        $json = file_get_contents($url ?? $GLOBALS['NEO_BROWSER'] ?? ('http://' . ($GLOBALS['NEO_HOST'] ?? 'localhost') . ':7474/'));
+        $decoded = json_decode($json, true);
+        if (json_last_error() !== JSON_ERROR_NONE)
+            $this->markTestIncomplete('Not able to obtain Neo4j version through HTTP');
+
+        $neo4jVersion = $decoded['neo4j_version'];
+
+//        if (version_compare($neo4jVersion, '5.13', '>='))
+//            return 5.4;
+        if (version_compare($neo4jVersion, '5.9', '>='))
+            return 5.3;
+        if (version_compare($neo4jVersion, '5.7', '>='))
+            return 5.2;
+        if (version_compare($neo4jVersion, '5.5', '>='))
+            return 5.1;
+        if (version_compare($neo4jVersion, '5.0', '>='))
+            return 5;
+        if (version_compare($neo4jVersion, '4.4', '>='))
+            return 4.4;
+        if (version_compare($neo4jVersion, '4.3', '>='))
+            return 4.3;
+        if (version_compare($neo4jVersion, '4.2', '>='))
+            return 4.2;
+        if (version_compare($neo4jVersion, '4.1', '>='))
+            return 4.1;
+        if (version_compare($neo4jVersion, '4', '>='))
+            return 4;
+        if (version_compare($neo4jVersion, '3.5', '>='))
+            return 3;
+        if (version_compare($neo4jVersion, '3.4', '>='))
+            return 2;
+        return 1;
     }
 }

--- a/tests/connection/ConnectionTest.php
+++ b/tests/connection/ConnectionTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\tests\connection;
 
 use Bolt\Bolt;
-use Bolt\protocol\{AProtocol, Response, V4_4, V5, V5_1};
+use Bolt\protocol\Response;
 use Bolt\tests\ATest;
 use Bolt\connection\{
     IConnection,
@@ -35,8 +35,7 @@ final class ConnectionTest extends ATest
     {
         $conn = $this->getConnection($alias);
         $conn->setTimeout(1.5);
-        /** @var AProtocol|V4_4|V5|V5_1 $protocol */
-        $protocol = (new Bolt($conn))->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = (new Bolt($conn))->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
         $this->expectException(ConnectionTimeoutException::class);
         $protocol
@@ -50,8 +49,7 @@ final class ConnectionTest extends ATest
     public function testLongNoTimeout(string $alias): void
     {
         $conn = $this->getConnection($alias);
-        /** @var AProtocol|V4_4|V5|V5_1 $protocol */
-        $protocol = (new Bolt($conn))->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = (new Bolt($conn))->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
         $conn->setTimeout(200);
         $protocol
@@ -66,8 +64,7 @@ final class ConnectionTest extends ATest
     {
         $conn = $this->getConnection($alias);
         $conn->setTimeout(1);
-        /** @var AProtocol|V4_4|V5|V5_1 $protocol */
-        $protocol = (new Bolt($conn))->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = (new Bolt($conn))->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
         $this->expectException(ConnectionTimeoutException::class);
         $protocol
@@ -81,8 +78,7 @@ final class ConnectionTest extends ATest
     public function testTimeoutRecoverAndReset(string $alias): void
     {
         $conn = $this->getConnection($alias);
-        /** @var AProtocol|V4_4|V5|V5_1 $protocol */
-        $protocol = (new Bolt($conn))->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = (new Bolt($conn))->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
 
         $conn->setTimeout(1.5);
@@ -106,8 +102,7 @@ final class ConnectionTest extends ATest
             ->getResponse();
 
         $this->assertEquals(Response::SIGNATURE_FAILURE, $response->getSignature());
-        /** @var AProtocol|V4_4|V5|V5_1 $protocol */
-        $protocol = (new Bolt($conn))->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = (new Bolt($conn))->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
 
         $conn->setTimeout(1.5);

--- a/tests/packstream/v1/BytesTest.php
+++ b/tests/packstream/v1/BytesTest.php
@@ -4,7 +4,7 @@ namespace Bolt\tests\packstream\v1;
 
 use Bolt\Bolt;
 use Bolt\packstream\Bytes;
-use Bolt\protocol\{AProtocol, V4_4, V5, V5_1};
+use Bolt\protocol\AProtocol;
 use Bolt\tests\ATest;
 
 /**
@@ -13,7 +13,7 @@ use Bolt\tests\ATest;
  */
 class BytesTest extends ATest
 {
-    public function testInit(): AProtocol|V4_4|V5|v5_1
+    public function testInit(): AProtocol
     {
         $conn = new \Bolt\connection\StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', $GLOBALS['NEO_PORT'] ?? 7687);
         $this->assertInstanceOf(\Bolt\connection\StreamSocket::class, $conn);
@@ -21,8 +21,7 @@ class BytesTest extends ATest
         $bolt = new Bolt($conn);
         $this->assertInstanceOf(Bolt::class, $bolt);
 
-        /** @var AProtocol|V4_4|V5|v5_1 $protocol */
-        $protocol = $bolt->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = $bolt->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->assertInstanceOf(AProtocol::class, $protocol);
 
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
@@ -34,7 +33,7 @@ class BytesTest extends ATest
      * @depends      testInit
      * @dataProvider providerBytes
      */
-    public function testBytes(Bytes $arr, AProtocol|V4_4|V5|v5_1 $protocol)
+    public function testBytes(Bytes $arr, AProtocol $protocol)
     {
         $res = iterator_to_array(
             $protocol

--- a/tests/packstream/v1/PackerTest.php
+++ b/tests/packstream/v1/PackerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\tests\packstream\v1;
 
 use Bolt\Bolt;
-use Bolt\protocol\{AProtocol, V4_4, V5, V5_1};
+use Bolt\protocol\AProtocol;
 use Bolt\tests\ATest;
 
 /**
@@ -15,7 +15,7 @@ use Bolt\tests\ATest;
  */
 class PackerTest extends ATest
 {
-    public function testInit(): AProtocol|V4_4|V5|v5_1
+    public function testInit(): AProtocol
     {
         $conn = new \Bolt\connection\StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', $GLOBALS['NEO_PORT'] ?? 7687);
         $this->assertInstanceOf(\Bolt\connection\StreamSocket::class, $conn);
@@ -23,8 +23,7 @@ class PackerTest extends ATest
         $bolt = new Bolt($conn);
         $this->assertInstanceOf(Bolt::class, $bolt);
 
-        /** @var AProtocol|V4_4|V5|v5_1 $protocol */
-        $protocol = $bolt->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = $bolt->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->assertInstanceOf(AProtocol::class, $protocol);
 
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
@@ -35,7 +34,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testNull(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testNull(AProtocol $protocol): void
     {
         $res = iterator_to_array(
             $protocol
@@ -50,7 +49,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testBoolean(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testBoolean(AProtocol $protocol): void
     {
         $res = iterator_to_array(
             $protocol
@@ -75,7 +74,7 @@ class PackerTest extends ATest
      * @depends      testInit
      * @dataProvider providerInteger
      */
-    public function testInteger(int $i, AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testInteger(int $i, AProtocol $protocol): void
     {
         $res = iterator_to_array(
             $protocol
@@ -98,7 +97,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testFloat(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testFloat(AProtocol $protocol): void
     {
         for ($i = 0; $i < 10; $i++) {
             $num = mt_rand(-mt_getrandmax(), mt_getrandmax()) / mt_getrandmax();
@@ -116,7 +115,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testString(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testString(AProtocol $protocol): void
     {
         $randomString = function (int $length) {
             $str = '';
@@ -141,7 +140,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testList(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testList(AProtocol $protocol): void
     {
         foreach ([0, 10, 200, 60000, 200000] as $size) {
             $arr = $this->randomArray($size);
@@ -168,7 +167,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testDictionary(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testDictionary(AProtocol $protocol): void
     {
         foreach ([0, 10, 200, 60000, 200000] as $size) {
             $arr = $this->randomArray($size);
@@ -186,7 +185,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testListGenerator(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testListGenerator(AProtocol $protocol): void
     {
         $data = [
             'first',
@@ -208,7 +207,7 @@ class PackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testDictionaryGenerator(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testDictionaryGenerator(AProtocol $protocol): void
     {
         $data = [
             'a' => 'first',

--- a/tests/packstream/v1/UnpackerTest.php
+++ b/tests/packstream/v1/UnpackerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\tests\packstream\v1;
 
 use Bolt\Bolt;
-use Bolt\protocol\{AProtocol, Response, V4_4, V5, V5_1};
+use Bolt\protocol\{AProtocol, Response};
 use Bolt\tests\ATest;
 
 /**
@@ -15,7 +15,7 @@ use Bolt\tests\ATest;
  */
 class UnpackerTest extends ATest
 {
-    public function testInit(): AProtocol|V4_4|V5|v5_1
+    public function testInit(): AProtocol
     {
         $conn = new \Bolt\connection\StreamSocket($GLOBALS['NEO_HOST'] ?? '127.0.0.1', $GLOBALS['NEO_PORT'] ?? 7687);
         $this->assertInstanceOf(\Bolt\connection\StreamSocket::class, $conn);
@@ -23,8 +23,7 @@ class UnpackerTest extends ATest
         $bolt = new Bolt($conn);
         $this->assertInstanceOf(Bolt::class, $bolt);
 
-        /** @var AProtocol|V4_4|V5|v5_1 $protocol */
-        $protocol = $bolt->setProtocolVersions(5.1, 5, 4.4)->build();
+        $protocol = $bolt->setProtocolVersions($this->getCompatibleBoltVersion())->build();
         $this->assertInstanceOf(AProtocol::class, $protocol);
 
         $this->sayHello($protocol, $GLOBALS['NEO_USER'], $GLOBALS['NEO_PASS']);
@@ -36,7 +35,7 @@ class UnpackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testNull(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testNull(AProtocol $protocol): void
     {
         $gen = $protocol
             ->run('RETURN null', [], ['mode' => 'r'])
@@ -53,7 +52,7 @@ class UnpackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testBoolean(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testBoolean(AProtocol $protocol): void
     {
         $gen = $protocol
             ->run('RETURN true, false', [], ['mode' => 'r'])
@@ -72,7 +71,7 @@ class UnpackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testInteger(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testInteger(AProtocol $protocol): void
     {
         $gen = $protocol
             ->run('RETURN -16, 0, 127, -17, -128, 128, 32767, 32768, 2147483647, 2147483648, 9223372036854775807, -129, -32768, -32769, -2147483648, -2147483649, -9223372036854775808', [], ['mode' => 'r'])
@@ -92,7 +91,7 @@ class UnpackerTest extends ATest
     /**
      * @depends testInit
      */
-    public function testFloat(AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testFloat(AProtocol $protocol): void
     {
         for ($i = 0; $i < 10; $i++) {
             $num = mt_rand(-mt_getrandmax(), mt_getrandmax()) / mt_getrandmax();
@@ -115,7 +114,7 @@ class UnpackerTest extends ATest
      * @depends      testInit
      * @dataProvider stringProvider
      */
-    public function testString(string $str, AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testString(string $str, AProtocol $protocol): void
     {
         $gen = $protocol
             ->run('RETURN "' . str_replace(['\\', '"'], ['\\\\', '\\"'], $str) . '" AS a', [], ['mode' => 'r'])
@@ -148,7 +147,7 @@ class UnpackerTest extends ATest
      * @depends      testInit
      * @dataProvider listProvider
      */
-    public function testList(int $size, AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testList(int $size, AProtocol $protocol): void
     {
         $gen = $protocol
             ->run('RETURN range(0, ' . $size . ') AS a', [], ['mode' => 'r'])
@@ -173,7 +172,7 @@ class UnpackerTest extends ATest
      * @depends      testInit
      * @dataProvider dictionaryProvider
      */
-    public function testDictionary(string $query, int $size, AProtocol|V4_4|V5|v5_1 $protocol): void
+    public function testDictionary(string $query, int $size, AProtocol $protocol): void
     {
         $gen = $protocol
             ->run($query, [], ['mode' => 'r'])

--- a/tests/protocol/V5_1Test.php
+++ b/tests/protocol/V5_1Test.php
@@ -1,7 +1,5 @@
 <?php
 
-
-use Bolt\helpers\Auth;
 use Bolt\protocol\Response;
 use Bolt\protocol\ServerState;
 use Bolt\protocol\V5_1;

--- a/tests/protocol/V5_3Test.php
+++ b/tests/protocol/V5_3Test.php
@@ -1,0 +1,45 @@
+<?php
+
+use Bolt\protocol\Response;
+use Bolt\protocol\ServerState;
+use Bolt\protocol\V5_3;
+
+/**
+ * Class V5_3Test
+ *
+ * @author Michal Stefanak
+ * @link https://github.com/neo4j-php/Bolt
+ * @package Bolt\tests\protocol
+ */
+class V5_3Test extends \Bolt\tests\protocol\ATest
+{
+    public function test__construct(): V5_3
+    {
+        $cls = new V5_3(1, $this->mockConnection(), new \Bolt\protocol\ServerState());
+        $this->assertInstanceOf(V5_3::class, $cls);
+        $cls->serverState->expectedServerStateMismatchCallback = function (string $current, array $expected) {
+            $this->markTestIncomplete('Server in ' . $current . ' state. Expected ' . implode(' or ', $expected) . '.');
+        };
+        return $cls;
+    }
+
+    /**
+     * @depends test__construct
+     */
+    public function testHello(V5_3 $cls): void
+    {
+        self::$readArray = [
+            [0x70, (object)[]],
+            [0x7F, (object)['message' => 'some error message', 'code' => 'Neo.ClientError.Statement.SyntaxError']]
+        ];
+
+        $cls->serverState->set(ServerState::CONNECTED);
+        $this->assertEquals(Response::SIGNATURE_SUCCESS, $cls->hello()->getSignature());
+        $this->assertEquals(ServerState::UNAUTHENTICATED, $cls->serverState->get());
+
+        $cls->serverState->set(ServerState::CONNECTED);
+        $response = $cls->hello();
+        $this->checkFailure($response);
+        $this->assertEquals(ServerState::DEFUNCT, $cls->serverState->get());
+    }
+}


### PR DESCRIPTION
- Added support for bolt 5.3
- Fixed bug with version 5.2
- Automatic identification of Neo4j version which is used to decide what bolt version use. Set Neo4j versions for GH Actions to test all possible bolt versions.
- Removed unnecessary type hints from tests so they don't have to be extended every time when there is new bolt version