### PR TITLE
Default protocol versions update

### DIFF
--- a/src/Bolt.php
+++ b/src/Bolt.php
@@ -33,7 +33,7 @@ final class Bolt
             $this->track();
         }
 
-        $this->setProtocolVersions(5.6, 5.4, 5, 4.4);
+        $this->setProtocolVersions('5.8.8', '4.4.4');
     }
 
     private function track(): void


### PR DESCRIPTION
This will be compatible backwards thanks to smart implementation of packing protocol versions and https://www.neo4j.com/docs/bolt/current/bolt/handshake/#bolt-version43